### PR TITLE
I had to check for these NULL objects to avoid segmentation faults on…

### DIFF
--- a/GUI/qIGTLIOConnectorModel.cxx
+++ b/GUI/qIGTLIOConnectorModel.cxx
@@ -56,8 +56,14 @@ int qIGTLIOConnectorModel::rowCount(const QModelIndex& parent) const
 
   // only topnode has children
   if (!parent.isValid())
+  {
+    if (!Logic)
+    {
+        std::cout << "WARNING in: int qIGTLIOConnectorModel::rowCount(const QModelIndex& parent) const: Logic is a NULL object! Returning 0." << std::endl;
+        return 0;
+    }
     return Logic->GetNumberOfConnectors();
-
+  }
   return 0;
 }
 

--- a/GUI/qIGTLIODevicesModel.cxx
+++ b/GUI/qIGTLIODevicesModel.cxx
@@ -52,6 +52,12 @@ int qIGTLIODevicesModel::rowCount(const QModelIndex& parent) const
     return 0;
 
   qIGTLIODevicesModelNode* node = this->getNodeFromIndex(parent);
+  if(!node)
+  {
+      std::cout << "WARNING in: int qIGTLIODevicesModel::rowCount(const QModelIndex& parent) const: node is a NULL object! Returning 0." << std::endl;
+      return 0;
+  }
+
   int r = node->GetNumberOfChildren();
   return r;
 }


### PR DESCRIPTION
… startup. The rowCount method was called before Logic was set. One theory is that the behaviour of one or more Qt classes has changed since the initial implementation. I am using QT 5.6. The error was in both debug and release. Now I get the application running, but with a slightly different GUI layout.
