### PR TITLE
Removed dependency on CTK

### DIFF
--- a/Examples/qIgtlClient/CMakeLists.txt
+++ b/Examples/qIgtlClient/CMakeLists.txt
@@ -17,9 +17,6 @@ find_package(VTK
   NO_MODULE)
 include(${VTK_USE_FILE})
 
-find_package(CTK REQUIRED)
-include(${CTK_USE_FILE})
-
 if( IGTLIO_QT_VERSION VERSION_GREATER "4" )
     find_package( Qt5 COMPONENTS Widgets REQUIRED )
     set( igtlclient_qt_libraries Qt5::Widgets )

--- a/Examples/qIgtlClient/CMakeLists.txt
+++ b/Examples/qIgtlClient/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(VTK
   COMPONENTS
   vtkIOImage
   vtkImagingMath
+  vtkGUISupportQt
   REQUIRED
   NO_MODULE)
 include(${VTK_USE_FILE})

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -11,12 +11,10 @@ find_package(VTK
   COMPONENTS
   vtkIOImage
   vtkImagingMath
+  vtkGUISupportQt
   REQUIRED
   NO_MODULE)
 include(${VTK_USE_FILE})
-
-find_package(CTK REQUIRED)
-include(${CTK_USE_FILE})
 
 set(EXECUTABLE ${PROJECT_NAME})
 
@@ -30,6 +28,7 @@ endif()
 set(${KIT}_SRCS
   qIGTLIOGuiUtilities.cxx
   qIGTLIOGuiUtilities.h
+  qIGTLIOVtkConnectionMacro.h
   qIGTLIOLogicController.cxx
   qIGTLIOLogicController.h
   qIGTLIOClientWidget.cxx
@@ -106,7 +105,6 @@ endif()
 set(${KIT}_TARGET_LIBRARIES
   ${OpenIGTLink_LIBRARIES}
   ${VTK_LIBRARIES}
-  ${CTK_LIBRARIES}
   ${igtlio_qt_libraries}
   igtlioLogic
   )

--- a/GUI/DeviceWidgets/qIGTLIOCommandDeviceWidget.h
+++ b/GUI/DeviceWidgets/qIGTLIOCommandDeviceWidget.h
@@ -8,9 +8,6 @@ class QGridLayout;
 class QComboBox;
 class QTextEdit;
 
-// CTK includes
-#include <ctkVTKObject.h>
-
 class OPENIGTLINKIO_GUI_EXPORT vtkIGTLIOCommandDeviceWidgetCreator : public vtkIGTLIODeviceWidgetCreator
 {
 public:

--- a/GUI/DeviceWidgets/qIGTLIODeviceWidget.h
+++ b/GUI/DeviceWidgets/qIGTLIODeviceWidget.h
@@ -9,8 +9,7 @@
 #include <vtkSmartPointer.h>
 #include <vtkObject.h>
 
-// CTK includes
-#include <ctkVTKObject.h>
+#include "qIGTLIOVtkConnectionMacro.h"
 
 class vtkIGTLIODevice;
 class qIGTLIODeviceWidget;
@@ -30,7 +29,7 @@ public:
 class OPENIGTLINKIO_GUI_EXPORT qIGTLIODeviceWidget : public QWidget
 {
   Q_OBJECT
-  QVTK_OBJECT
+  IGTLIO_QVTK_OBJECT
 public:
   qIGTLIODeviceWidget(QWidget* parent=NULL);
   virtual void SetDevice(vtkSmartPointer<vtkIGTLIODevice> device);

--- a/GUI/DeviceWidgets/qIGTLIOStatusDeviceWidget.h
+++ b/GUI/DeviceWidgets/qIGTLIOStatusDeviceWidget.h
@@ -7,9 +7,6 @@
 class QLineEdit;
 class QGridLayout;
 
-// CTK includes
-#include <ctkVTKObject.h>
-
 class OPENIGTLINKIO_GUI_EXPORT vtkIGTLIOStatusDeviceWidgetCreator : public vtkIGTLIODeviceWidgetCreator
 {
 public:

--- a/GUI/qIGTLIOConnectorListWidget.cxx
+++ b/GUI/qIGTLIOConnectorListWidget.cxx
@@ -95,7 +95,7 @@ void qIGTLIOConnectorListWidget::setLogic(vtkIGTLIOLogicPointer logic)
           << vtkIGTLIOLogic::ConnectionAboutToBeRemovedEvent)
     {
     qvtkReconnect(this->Logic, logic, evendId,
-                  this, SLOT(onConnectionsChanged(vtkObject*, void*, unsigned long, void*)));
+                  this, SLOT(onConnectionsChanged(vtkObject*, unsigned long, void*, void*)));
     }
 
   this->Logic = logic;
@@ -103,7 +103,7 @@ void qIGTLIOConnectorListWidget::setLogic(vtkIGTLIOLogicPointer logic)
 }
 
 //-----------------------------------------------------------------------------
-void qIGTLIOConnectorListWidget::onConnectionsChanged(vtkObject* caller, void* connector, unsigned long event , void* b)
+void qIGTLIOConnectorListWidget::onConnectionsChanged(vtkObject* caller, unsigned long event, void * clientData,  void* connector)
 {
   // remove removed connector from property widget
   if (event==vtkIGTLIOLogic::ConnectionAboutToBeRemovedEvent && connector!=NULL)

--- a/GUI/qIGTLIOConnectorListWidget.h
+++ b/GUI/qIGTLIOConnectorListWidget.h
@@ -3,8 +3,7 @@
 
 #include <QWidget>
 
-// CTK includes
-#include <ctkVTKObject.h>
+#include "qIGTLIOVtkConnectionMacro.h"
 
 // igtlio includes
 #include "igtlioGUIExport.h"
@@ -23,7 +22,7 @@ typedef vtkSmartPointer<class vtkIGTLIOLogic> vtkIGTLIOLogicPointer;
 class OPENIGTLINKIO_GUI_EXPORT qIGTLIOConnectorListWidget : public QWidget
 {
   Q_OBJECT
-  QVTK_OBJECT
+  IGTLIO_QVTK_OBJECT
 
 public:
   qIGTLIOConnectorListWidget();
@@ -32,7 +31,7 @@ public:
 signals:
 
 private slots:
-  void onConnectionsChanged(vtkObject *caller, void *, unsigned long event, void *);
+  void onConnectionsChanged(vtkObject* caller, unsigned long event, void * clientData,  void* connector);
   void onCurrentConnectorChanged();
 private slots:
   void onAddConnectorButtonClicked();

--- a/GUI/qIGTLIOConnectorModel.cxx
+++ b/GUI/qIGTLIOConnectorModel.cxx
@@ -172,7 +172,7 @@ void qIGTLIOConnectorModel::setLogic(vtkIGTLIOLogicPointer logic)
           << vtkIGTLIOLogic::ConnectionAboutToBeRemovedEvent)
     {
     qvtkReconnect(this->Logic, logic, evendId,
-                  this, SLOT(onConnectionEvent(vtkObject*, void*, unsigned long, void*)));
+                  this, SLOT(onConnectionEvent(vtkObject*, unsigned long, void*, void* )));
     }
 
   this->Logic = logic;
@@ -188,12 +188,12 @@ void qIGTLIOConnectorModel::ReconnectConnector(vtkIGTLIOConnector* oldConnector,
           << vtkIGTLIOConnector::DeactivatedEvent)
     {
     qvtkReconnect(oldConnector, newConnector, evendId,
-                  this, SLOT(onConnectorEvent(vtkObject*, void*, unsigned long, void*)));
+                  this, SLOT(onConnectorEvent(vtkObject*, unsigned long, void*, void* )));
     }
 }
 
 //-----------------------------------------------------------------------------
-void qIGTLIOConnectorModel::onConnectionEvent(vtkObject* caller, void* connector, unsigned long event , void*)
+void qIGTLIOConnectorModel::onConnectionEvent(vtkObject* caller, unsigned long event, void * , void* connector )
 {
   if (event==vtkIGTLIOLogic::ConnectionAddedEvent)
     {
@@ -212,7 +212,7 @@ void qIGTLIOConnectorModel::onConnectionEvent(vtkObject* caller, void* connector
 }
 
 //-----------------------------------------------------------------------------
-void qIGTLIOConnectorModel::onConnectorEvent(vtkObject* caller, void* connector, unsigned long event , void*)
+void qIGTLIOConnectorModel::onConnectorEvent(vtkObject* caller, unsigned long event , void*, void* connector )
 {
   emit dataChanged(QModelIndex(), QModelIndex());
 }

--- a/GUI/qIGTLIOConnectorModel.h
+++ b/GUI/qIGTLIOConnectorModel.h
@@ -24,8 +24,7 @@
 #include <QAbstractItemModel>
 #include <QStringList>
 
-// CTK includes
-#include <ctkVTKObject.h>
+#include "qIGTLIOVtkConnectionMacro.h"
 
 // igtlio includes
 #include "igtlioGUIExport.h"
@@ -39,7 +38,7 @@ typedef vtkSmartPointer<class vtkIGTLIOLogic> vtkIGTLIOLogicPointer;
 class OPENIGTLINKIO_GUI_EXPORT qIGTLIOConnectorModel : public QAbstractItemModel
 {
   Q_OBJECT
-  QVTK_OBJECT
+  IGTLIO_QVTK_OBJECT
 
 public:
   qIGTLIOConnectorModel(QObject *parent=0);
@@ -65,8 +64,8 @@ public:
   };
 
 private slots:
-  void onConnectorEvent(vtkObject *caller, void *connector, unsigned long event, void *);
-  void onConnectionEvent(vtkObject *caller, void *, unsigned long, void *);
+  void onConnectorEvent(vtkObject *caller, unsigned long event, void *, void *connector );
+  void onConnectionEvent(vtkObject *caller, unsigned long, void *, void * );
 
 private:
   Q_DISABLE_COPY(qIGTLIOConnectorModel);

--- a/GUI/qIGTLIOConnectorPropertyWidget.cxx
+++ b/GUI/qIGTLIOConnectorPropertyWidget.cxx
@@ -9,10 +9,6 @@
 // OpenIGTLinkIF MRML includes
 #include "vtkIGTLIOConnector.h"
 
-// CTK includes
-#include <ctkVTKObject.h>
-
-
 //------------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_OpenIGTLinkIF
 class qIGTLIOConnectorPropertyWidgetPrivate : public Ui_qIGTLIOConnectorPropertyWidget

--- a/GUI/qIGTLIOConnectorPropertyWidget.h
+++ b/GUI/qIGTLIOConnectorPropertyWidget.h
@@ -24,8 +24,7 @@
 // Qt includes
 #include <QWidget>
 
-// CTK includes
-#include <ctkVTKObject.h>
+#include "qIGTLIOVtkConnectionMacro.h"
 
 // igtlio includes
 #include "igtlioGUIExport.h"
@@ -42,7 +41,7 @@ class vtkObject;
 class OPENIGTLINKIO_GUI_EXPORT qIGTLIOConnectorPropertyWidget : public QWidget
 {
   Q_OBJECT
-  QVTK_OBJECT
+  IGTLIO_QVTK_OBJECT
 public:
   typedef QWidget Superclass;
   qIGTLIOConnectorPropertyWidget(QWidget *parent = 0);

--- a/GUI/qIGTLIODeviceAddWidget.h
+++ b/GUI/qIGTLIODeviceAddWidget.h
@@ -3,9 +3,6 @@
 
 #include <QWidget>
 
-// CTK includes
-#include <ctkVTKObject.h>
-
 // igtlio includes
 #include "igtlioGUIExport.h"
 

--- a/GUI/qIGTLIODeviceButtonsWidget.h
+++ b/GUI/qIGTLIODeviceButtonsWidget.h
@@ -3,9 +3,6 @@
 
 #include <QWidget>
 
-// CTK includes
-#include <ctkVTKObject.h>
-
 // igtlio includes
 #include "igtlioGUIExport.h"
 

--- a/GUI/qIGTLIODevicesModel.cxx
+++ b/GUI/qIGTLIODevicesModel.cxx
@@ -223,7 +223,7 @@ void qIGTLIODevicesModel::setLogic(vtkIGTLIOLogicPointer logic)
           << vtkIGTLIOLogic::ConnectionAboutToBeRemovedEvent)
     {
     qvtkReconnect(this->Logic, logic, evendId,
-                  this, SLOT(onConnectionEvent(vtkObject*, void*, unsigned long, void*)));
+                  this, SLOT(onConnectionEvent(vtkObject*, unsigned long, void*, void*)));
     }
 
   this->Logic = logic;
@@ -261,12 +261,12 @@ void qIGTLIODevicesModel::ReconnectConnector(vtkIGTLIOConnector* oldConnector, v
           )
     {
     qvtkReconnect(oldConnector, newConnector, evendId,
-                  this, SLOT(onConnectorEvent(vtkObject*, void*, unsigned long, void*)));
+                  this, SLOT(onConnectorEvent(vtkObject*, unsigned long, void*, void*)));
     }
 }
 
 //-----------------------------------------------------------------------------
-void qIGTLIODevicesModel::onConnectionEvent(vtkObject* caller, void* connector, unsigned long event , void*)
+void qIGTLIODevicesModel::onConnectionEvent(vtkObject* caller, unsigned long event , void*, void* connector)
 {
   if (event==vtkIGTLIOLogic::ConnectionAddedEvent)
     {
@@ -285,7 +285,7 @@ void qIGTLIODevicesModel::onConnectionEvent(vtkObject* caller, void* connector, 
 }
 
 //-----------------------------------------------------------------------------
-void qIGTLIODevicesModel::onConnectorEvent(vtkObject* caller, void* c, unsigned long event , void*)
+void qIGTLIODevicesModel::onConnectorEvent(vtkObject* caller, unsigned long event , void*, void* c)
 {
   if (event==vtkIGTLIOConnector::NewDeviceEvent)
     {

--- a/GUI/qIGTLIODevicesModel.h
+++ b/GUI/qIGTLIODevicesModel.h
@@ -4,8 +4,7 @@
 #include <QAbstractItemModel>
 #include <QStringList>
 
-// CTK includes
-#include <ctkVTKObject.h>
+#include "qIGTLIOVtkConnectionMacro.h"
 
 // igtlio includes
 #include "igtlioGUIExport.h"
@@ -25,7 +24,7 @@ class QItemSelectionModel;
 class OPENIGTLINKIO_GUI_EXPORT qIGTLIODevicesModel : public QAbstractItemModel
 {
   Q_OBJECT
-  QVTK_OBJECT
+  IGTLIO_QVTK_OBJECT
 
 public:
   qIGTLIODevicesModel(QObject *parent=0);
@@ -65,8 +64,8 @@ public:
   qIGTLIODevicesModelNode* getNodeFromIndex(const QModelIndex& index) const;
 
 private slots:
-  void onConnectorEvent(vtkObject *caller, void *connector, unsigned long event, void *);
-  void onConnectionEvent(vtkObject *caller, void *connector, unsigned long, void *);
+  void onConnectorEvent(vtkObject *caller, unsigned long event, void *, void *connector);
+  void onConnectionEvent(vtkObject *caller, unsigned long, void *, void *connector);
 private:
   Q_DISABLE_COPY(qIGTLIODevicesModel);
 

--- a/GUI/qIGTLIODevicesWidget.cxx
+++ b/GUI/qIGTLIODevicesWidget.cxx
@@ -63,7 +63,7 @@ void qIGTLIODevicesWidget::setLogic(vtkIGTLIOLogicPointer logic)
           << vtkIGTLIOLogic::ConnectionAboutToBeRemovedEvent)
     {
     qvtkReconnect(this->Logic, logic, evendId,
-                  this, SLOT(onConnectionsChanged(vtkObject*, void*, unsigned long, void*)));
+                  this, SLOT(onConnectionsChanged(vtkObject*, unsigned long, void*, void*)));
     }
 
   this->Logic = logic;
@@ -72,7 +72,7 @@ void qIGTLIODevicesWidget::setLogic(vtkIGTLIOLogicPointer logic)
 }
 
 //-----------------------------------------------------------------------------
-void qIGTLIODevicesWidget::onConnectionsChanged(vtkObject* caller, void* connector, unsigned long event , void* b)
+void qIGTLIODevicesWidget::onConnectionsChanged(vtkObject* caller, unsigned long event , void* b, void* connector)
 {
 //  std::cout << "onConnectionsChanged " << std::endl;
 }

--- a/GUI/qIGTLIODevicesWidget.h
+++ b/GUI/qIGTLIODevicesWidget.h
@@ -3,8 +3,7 @@
 
 #include <QWidget>
 
-// CTK includes
-#include <ctkVTKObject.h>
+#include "qIGTLIOVtkConnectionMacro.h"
 
 // igtlio includes
 #include "igtlioGUIExport.h"
@@ -24,7 +23,7 @@ typedef vtkSmartPointer<class vtkIGTLIOLogic> vtkIGTLIOLogicPointer;
 class OPENIGTLINKIO_GUI_EXPORT qIGTLIODevicesWidget : public QWidget
 {
   Q_OBJECT
-  QVTK_OBJECT
+  IGTLIO_QVTK_OBJECT
 public:
   qIGTLIODevicesWidget();
   void setLogic(vtkIGTLIOLogicPointer logic);
@@ -32,7 +31,7 @@ public:
 signals:
 
 private slots:
-  void onConnectionsChanged(vtkObject *caller, void *connector, unsigned long event, void *b);
+  void onConnectionsChanged(vtkObject *caller, unsigned long event, void *b, void *connector );
   void onCurrentDeviceChanged(const QModelIndex &current, const QModelIndex &previous);
 private:
   vtkIGTLIOLogicPointer Logic;

--- a/GUI/qIGTLIOLogicController.h
+++ b/GUI/qIGTLIOLogicController.h
@@ -3,8 +3,8 @@
 
 #include <QObject>
 class QTimer;
-// CTK includes
-#include <ctkVTKObject.h>
+
+#include "qIGTLIOVtkConnectionMacro.h"
 
 #include <vtkSmartPointer.h>
 typedef vtkSmartPointer<class vtkIGTLIOLogic> vtkIGTLIOLogicPointer;
@@ -16,7 +16,7 @@ typedef vtkSmartPointer<class vtkIGTLIOLogic> vtkIGTLIOLogicPointer;
 class OPENIGTLINKIO_GUI_EXPORT qIGTLIOLogicController : public QObject
 {
   Q_OBJECT
-  QVTK_OBJECT
+  IGTLIO_QVTK_OBJECT
 
 public:
   qIGTLIOLogicController();

--- a/GUI/qIGTLIOVtkConnectionMacro.h
+++ b/GUI/qIGTLIOVtkConnectionMacro.h
@@ -1,0 +1,30 @@
+#ifndef QIGTLIOVTKCONNECTIONMACRO_H
+#define QIGTLIOVTKCONNECTIONMACRO_H
+
+#include "vtkEventQtSlotConnect.h"
+
+#define IGTLIO_QVTK_OBJECT_RECONNECT_METHOD                                 \
+void qvtkReconnect( vtkObject* old_vtk_obj, vtkObject* vtk_obj,             \
+                    unsigned long vtk_event, const QObject* qt_obj,         \
+                    const char* qt_slot, float priority = 0.0,              \
+                    Qt::ConnectionType connectionType = Qt::AutoConnection) \
+{ \
+    MyQVTK.connectPtr->Disconnect( old_vtk_obj, vtk_event, qt_obj, qt_slot ); \
+    MyQVTK.connectPtr->Connect( vtk_obj, vtk_event, qt_obj, qt_slot, NULL, priority, connectionType ); \
+}
+
+
+#define IGTLIO_QVTK_OBJECT                         \
+protected:                                         \
+  IGTLIO_QVTK_OBJECT_RECONNECT_METHOD              \
+private:                                           \
+class QVTKConnect  \
+{  \
+public:  \
+    QVTKConnect() { connectPtr = vtkEventQtSlotConnect::New(); } \
+    ~QVTKConnect() { connectPtr->Delete(); }  \
+    vtkEventQtSlotConnect * connectPtr;  \
+};  \
+QVTKConnect MyQVTK;  \
+
+#endif // QIGTLIOVTKCONNECTIONMACRO_H

--- a/GUI/qIGTLIOVtkConnectionMacro.h
+++ b/GUI/qIGTLIOVtkConnectionMacro.h
@@ -9,8 +9,11 @@ void qvtkReconnect( vtkObject* old_vtk_obj, vtkObject* vtk_obj,             \
                     const char* qt_slot, float priority = 0.0,              \
                     Qt::ConnectionType connectionType = Qt::AutoConnection) \
 { \
-    MyQVTK.connectPtr->Disconnect( old_vtk_obj, vtk_event, qt_obj, qt_slot ); \
-    MyQVTK.connectPtr->Connect( vtk_obj, vtk_event, qt_obj, qt_slot, NULL, priority, connectionType ); \
+    Q_ASSERT( qt_obj ); \
+    if( old_vtk_obj ) \
+        MyQVTK.connectPtr->Disconnect( old_vtk_obj, vtk_event, qt_obj, qt_slot ); \
+    if( vtk_obj ) \
+        MyQVTK.connectPtr->Connect( vtk_obj, vtk_event, qt_obj, qt_slot, NULL, priority, connectionType ); \
 }
 
 


### PR DESCRIPTION
Now, we use the vtkEventQtSlotConnect class from vtk to connect vtkObject and QObject instead of the CTK mechanism.
