### PR TITLE
1. Meta information setting, 2. device modified event observed by connector

### DIFF
--- a/Converter/igtlioBaseConverter.h
+++ b/Converter/igtlioBaseConverter.h
@@ -30,17 +30,6 @@ namespace igtlio
 class OPENIGTLINKIO_CONVERTER_EXPORT BaseConverter
 {
 public:
-	enum EQUIPMENT_TYPE {
-		UNKNOWN = 0,
-		VIDEO, //images
-		US_PROBE, //images + strings/params
-		CONTROLLER, //strings/params (us_scanner, hardware controlling something, ekg...)
-		TRACKED_TOOL, //transforms
-		TRACKED_VIDEO, //transforms + images
-		TRACKED_US_PROBE //images + transforms + strings/params
-	};
-
-public:
   /**
    * This structure contains data common to all igtl messages,
    * TODO: add header xml-data here.
@@ -49,16 +38,12 @@ public:
   {
   std::string deviceName;
   double timestamp;
-  EQUIPMENT_TYPE equipmentType;
-  std::string equipmentId;
-  std::string streamId;
   };
 
-  static int IGTLtoHeader(igtl::MessageBase::Pointer source, HeaderData* header);
-  static int HeadertoIGTL(const HeaderData& header, igtl::MessageBase::Pointer* dest);
+  static int IGTLtoHeader(igtl::MessageBase::Pointer source, HeaderData* header, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int HeadertoIGTL(const HeaderData& header, igtl::MessageBase::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
 
   static int IGTLToTimestamp(igtl::MessageBase::Pointer msg, HeaderData *dest);
-
 };
 
 } // namespace igtlio

--- a/Converter/igtlioCommandConverter.cxx
+++ b/Converter/igtlioCommandConverter.cxx
@@ -85,6 +85,7 @@ int CommandConverter::toIGTL(const HeaderData& header, const ContentData& source
 {
   if (dest->IsNull())
     *dest = igtl::CommandMessage::New();
+  (*dest)->InitPack();
   igtl::CommandMessage::Pointer msg = *dest;
   if (metaInfo!=NULL)
     msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
@@ -94,7 +95,6 @@ int CommandConverter::toIGTL(const HeaderData& header, const ContentData& source
   msg->SetCommandId(source.id);
   msg->SetCommandName(source.name);
   msg->SetCommandContent(source.content);
-
   msg->Pack();
 
   return 1;

--- a/Converter/igtlioCommandConverter.cxx
+++ b/Converter/igtlioCommandConverter.cxx
@@ -86,7 +86,8 @@ int CommandConverter::toIGTL(const HeaderData& header, const ContentData& source
   if (dest->IsNull())
     *dest = igtl::CommandMessage::New();
   igtl::CommandMessage::Pointer msg = *dest;
-
+  if (metaInfo!=NULL)
+    msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
   HeadertoIGTL(header, &basemsg, metaInfo);
 

--- a/Converter/igtlioCommandConverter.cxx
+++ b/Converter/igtlioCommandConverter.cxx
@@ -18,7 +18,7 @@ std::vector<std::string> CommandConverter::GetAvailableCommandNames()
 int CommandConverter::fromIGTL(igtl::MessageBase::Pointer source,
                              HeaderData* header,
                              ContentData* dest,
-                             bool checkCRC)
+                             bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   // Create a message buffer to receive  data
   igtl::CommandMessage::Pointer msg;
@@ -36,7 +36,7 @@ int CommandConverter::fromIGTL(igtl::MessageBase::Pointer source,
     }
 
   // get header
-  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header))
+  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header, metaInfo))
     return 0;
 
   dest->id = msg->GetCommandId();
@@ -49,7 +49,7 @@ int CommandConverter::fromIGTL(igtl::MessageBase::Pointer source,
 int CommandConverter::fromIGTLResponse(igtl::MessageBase::Pointer source,
                              HeaderData* header,
                              ContentData* dest,
-                             bool checkCRC)
+                             bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   //TODO: merge this method with fromIGTL(),
 
@@ -69,7 +69,7 @@ int CommandConverter::fromIGTLResponse(igtl::MessageBase::Pointer source,
     }
 
   // get header
-  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header))
+  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header, metaInfo))
     return 0;
 
   dest->id = msg->GetCommandId();
@@ -81,14 +81,14 @@ int CommandConverter::fromIGTLResponse(igtl::MessageBase::Pointer source,
 
 
 //---------------------------------------------------------------------------
-int CommandConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::CommandMessage::Pointer* dest)
+int CommandConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::CommandMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   if (dest->IsNull())
     *dest = igtl::CommandMessage::New();
   igtl::CommandMessage::Pointer msg = *dest;
 
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
-  HeadertoIGTL(header, &basemsg);
+  HeadertoIGTL(header, &basemsg, metaInfo);
 
   msg->SetCommandId(source.id);
   msg->SetCommandName(source.name);

--- a/Converter/igtlioCommandConverter.h
+++ b/Converter/igtlioCommandConverter.h
@@ -33,9 +33,9 @@ public:
   static const char* GetIGTLResponseName() { return "RTS_COMMAND"; }
 
 
-  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC);
-  static int fromIGTLResponse(igtl::MessageBase::Pointer source, HeaderData *header, ContentData *dest, bool checkCRC);
-  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::CommandMessage::Pointer* dest);
+  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int fromIGTLResponse(igtl::MessageBase::Pointer source, HeaderData *header, ContentData *dest, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::CommandMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo= NULL);
 
   static std::vector<std::string> GetAvailableCommandNames();
 };

--- a/Converter/igtlioImageConverter.cxx
+++ b/Converter/igtlioImageConverter.cxx
@@ -72,7 +72,7 @@ namespace igtlio
 int ImageConverter::fromIGTL(igtl::MessageBase::Pointer source,
                              HeaderData* header,
                              ContentData* dest,
-                             bool checkCRC)
+                             bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   // Create a message buffer to receive image data
   igtl::ImageMessage::Pointer imgMsg;
@@ -90,7 +90,7 @@ int ImageConverter::fromIGTL(igtl::MessageBase::Pointer source,
     }
 
   // get header
-  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(imgMsg), header))
+  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(imgMsg), header, metaInfo))
     return 0;
 
   // get image
@@ -435,14 +435,14 @@ int ImageConverter::VTKTransformToIGTLImage(const vtkMatrix4x4& ijk2ras, int ima
 }
 
 //---------------------------------------------------------------------------
-int ImageConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::ImageMessage::Pointer* dest)
+int ImageConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::ImageMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   if (dest->IsNull())
     *dest = igtl::ImageMessage::New();
   igtl::ImageMessage::Pointer msg = *dest;
 
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
-  HeadertoIGTL(header, &basemsg);
+  HeadertoIGTL(header, &basemsg, metaInfo);
 
   if (source.transform.Get()==NULL)
     std::cerr << "Got NULL input transform" << std::endl;

--- a/Converter/igtlioImageConverter.cxx
+++ b/Converter/igtlioImageConverter.cxx
@@ -440,7 +440,8 @@ int ImageConverter::toIGTL(const HeaderData& header, const ContentData& source, 
   if (dest->IsNull())
     *dest = igtl::ImageMessage::New();
   igtl::ImageMessage::Pointer msg = *dest;
-
+  if (metaInfo!=NULL)
+    msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
   HeadertoIGTL(header, &basemsg, metaInfo);
 

--- a/Converter/igtlioImageConverter.h
+++ b/Converter/igtlioImageConverter.h
@@ -46,8 +46,8 @@ public:
   static const char*  GetIGTLName() { return GetIGTLTypeName(); }
   static const char* GetIGTLTypeName() { return "IMAGE"; }
 
-  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC);
-  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::ImageMessage::Pointer* dest);
+  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::ImageMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
 
   static int IGTLToVTKScalarType(int igtlType);
   static int IGTLToVTKImageData(igtl::ImageMessage::Pointer imgMsg, ContentData* dest);

--- a/Converter/igtlioPolyDataConverter.cxx
+++ b/Converter/igtlioPolyDataConverter.cxx
@@ -230,6 +230,8 @@ int PolyDataConverter::toIGTL(const HeaderData &header, const PolyDataConverter:
    if (dest->IsNull())
 	 *dest = igtl::PolyDataMessage::New();
    igtl::PolyDataMessage::Pointer outMessage = *dest;
+   if (metaInfo!=NULL)
+    outMessage->SetHeaderVersion(IGTL_HEADER_VERSION_2);
 
    igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(outMessage);
    HeadertoIGTL(header, &basemsg, metaInfo);

--- a/Converter/igtlioPolyDataConverter.cxx
+++ b/Converter/igtlioPolyDataConverter.cxx
@@ -29,7 +29,7 @@ namespace igtlio
 {
 
 //---------------------------------------------------------------------------
-int PolyDataConverter::fromIGTL(igtl::MessageBase::Pointer source, HeaderData *header, PolyDataConverter::ContentData *dest, bool checkCRC)
+int PolyDataConverter::fromIGTL(igtl::MessageBase::Pointer source, HeaderData *header, PolyDataConverter::ContentData *dest, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo)
 {
  // Create a message buffer to receive image data
  igtl::PolyDataMessage::Pointer polyDataMsg;
@@ -47,7 +47,7 @@ int PolyDataConverter::fromIGTL(igtl::MessageBase::Pointer source, HeaderData *h
    }
 
  // get header
- if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(polyDataMsg), header))
+ if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(polyDataMsg), header, metaInfo))
    return 0;
 
  vtkSmartPointer<vtkPolyData> poly = vtkSmartPointer<vtkPolyData>::New();
@@ -219,7 +219,7 @@ int PolyDataConverter::IGTLToVTKPolyData(igtl::PolyDataMessage::Pointer polyData
 }
 
 //---------------------------------------------------------------------------
-int PolyDataConverter::toIGTL(const HeaderData &header, const PolyDataConverter::ContentData &source, igtl::PolyDataMessage::Pointer *dest)
+int PolyDataConverter::toIGTL(const HeaderData &header, const PolyDataConverter::ContentData &source, igtl::PolyDataMessage::Pointer *dest, igtl::MessageBase::MetaDataMap* metaInfo)
 {
    if (source.polydata.GetPointer() == NULL)
      {
@@ -232,7 +232,7 @@ int PolyDataConverter::toIGTL(const HeaderData &header, const PolyDataConverter:
    igtl::PolyDataMessage::Pointer outMessage = *dest;
 
    igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(outMessage);
-   HeadertoIGTL(header, &basemsg);
+   HeadertoIGTL(header, &basemsg, metaInfo);
 
    // Set message name -- use the same name as the MRML node
    outMessage->SetDeviceName(source.deviceName.c_str());

--- a/Converter/igtlioPolyDataConverter.cxx
+++ b/Converter/igtlioPolyDataConverter.cxx
@@ -228,7 +228,9 @@ int PolyDataConverter::toIGTL(const HeaderData &header, const PolyDataConverter:
      }
 
    if (dest->IsNull())
-	 *dest = igtl::PolyDataMessage::New();
+     *dest = igtl::PolyDataMessage::New();
+   (*dest)->Clear();
+   (*dest)->InitPack();
    igtl::PolyDataMessage::Pointer outMessage = *dest;
    if (metaInfo!=NULL)
     outMessage->SetHeaderVersion(IGTL_HEADER_VERSION_2);

--- a/Converter/igtlioPolyDataConverter.h
+++ b/Converter/igtlioPolyDataConverter.h
@@ -46,8 +46,8 @@ public:
   static const char*  GetIGTLName() { return GetIGTLTypeName(); }
   static const char* GetIGTLTypeName() { return "POLYDATA"; }
 
-  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* dest, bool checkCRC);
-  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::PolyDataMessage::Pointer* dest);
+  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* dest, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::PolyDataMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
 
   // Extract vtkPolyData from existing polyDataMsg, insert into existing poly.
   static int IGTLToVTKPolyData(igtl::PolyDataMessage::Pointer polyDataMsg, vtkSmartPointer<vtkPolyData> poly);

--- a/Converter/igtlioStatusConverter.cxx
+++ b/Converter/igtlioStatusConverter.cxx
@@ -44,6 +44,7 @@ int StatusConverter::toIGTL(const HeaderData& header, const ContentData& source,
 {
   if (dest->IsNull())
     *dest = igtl::StatusMessage::New();
+  (*dest)->InitPack();  
   igtl::StatusMessage::Pointer msg = *dest;
   if (metaInfo!=NULL)
     msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
@@ -54,7 +55,6 @@ int StatusConverter::toIGTL(const HeaderData& header, const ContentData& source,
   msg->SetSubCode(source.code);
   msg->SetErrorName(source.errorname.c_str());
   msg->SetStatusString(source.statusstring.c_str());
-
   msg->Pack();
 
   return 1;

--- a/Converter/igtlioStatusConverter.cxx
+++ b/Converter/igtlioStatusConverter.cxx
@@ -45,7 +45,8 @@ int StatusConverter::toIGTL(const HeaderData& header, const ContentData& source,
   if (dest->IsNull())
     *dest = igtl::StatusMessage::New();
   igtl::StatusMessage::Pointer msg = *dest;
-
+  if (metaInfo!=NULL)
+    msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
   HeadertoIGTL(header, &basemsg, metaInfo);
 

--- a/Converter/igtlioStatusConverter.cxx
+++ b/Converter/igtlioStatusConverter.cxx
@@ -10,7 +10,7 @@ namespace igtlio
 int StatusConverter::fromIGTL(igtl::MessageBase::Pointer source,
                              HeaderData* header,
                              ContentData* dest,
-                             bool checkCRC)
+                             bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   // Create a message buffer to receive  data
   igtl::StatusMessage::Pointer msg;
@@ -28,7 +28,7 @@ int StatusConverter::fromIGTL(igtl::MessageBase::Pointer source,
     }
 
   // get header
-  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header))
+  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header, metaInfo))
     return 0;
 
   dest->code = msg->GetCode();
@@ -40,14 +40,14 @@ int StatusConverter::fromIGTL(igtl::MessageBase::Pointer source,
 }
 
 //---------------------------------------------------------------------------
-int StatusConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::StatusMessage::Pointer* dest)
+int StatusConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::StatusMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   if (dest->IsNull())
     *dest = igtl::StatusMessage::New();
   igtl::StatusMessage::Pointer msg = *dest;
 
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
-  HeadertoIGTL(header, &basemsg);
+  HeadertoIGTL(header, &basemsg, metaInfo);
 
   msg->SetCode(source.code);
   msg->SetSubCode(source.code);

--- a/Converter/igtlioStatusConverter.h
+++ b/Converter/igtlioStatusConverter.h
@@ -26,8 +26,8 @@ public:
   static const char*  GetIGTLName() { return GetIGTLTypeName(); }
   static const char* GetIGTLTypeName() { return "STATUS"; }
 
-  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC);
-  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::StatusMessage::Pointer* dest);
+  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::StatusMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
 
 };
 

--- a/Converter/igtlioStringConverter.cxx
+++ b/Converter/igtlioStringConverter.cxx
@@ -43,7 +43,8 @@ int StringConverter::toIGTL(const HeaderData& header, const ContentData& source,
   if (dest->IsNull())
     *dest = igtl::StringMessage::New();
   igtl::StringMessage::Pointer msg = *dest;
-
+  if (metaInfo!=NULL)
+    msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
   HeadertoIGTL(header, &basemsg, metaInfo);
 

--- a/Converter/igtlioStringConverter.cxx
+++ b/Converter/igtlioStringConverter.cxx
@@ -42,6 +42,7 @@ int StringConverter::toIGTL(const HeaderData& header, const ContentData& source,
 {
   if (dest->IsNull())
     *dest = igtl::StringMessage::New();
+  (*dest)->InitPack();
   igtl::StringMessage::Pointer msg = *dest;
   if (metaInfo!=NULL)
     msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
@@ -50,7 +51,6 @@ int StringConverter::toIGTL(const HeaderData& header, const ContentData& source,
 
   msg->SetString(source.string_msg);
   msg->SetEncoding(source.encoding);
-
   msg->Pack();
 
   return 1;

--- a/Converter/igtlioStringConverter.cxx
+++ b/Converter/igtlioStringConverter.cxx
@@ -10,7 +10,7 @@ namespace igtlio
 int StringConverter::fromIGTL(igtl::MessageBase::Pointer source,
                              HeaderData* header,
                              ContentData* dest,
-                             bool checkCRC)
+                             bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   // Create a message buffer to receive  data
   igtl::StringMessage::Pointer msg;
@@ -28,7 +28,7 @@ int StringConverter::fromIGTL(igtl::MessageBase::Pointer source,
     }
 
   // get header
-  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header))
+  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(msg), header, metaInfo))
     return 0;
 
   dest->string_msg = msg->GetString();
@@ -38,14 +38,14 @@ int StringConverter::fromIGTL(igtl::MessageBase::Pointer source,
 }
 
 //---------------------------------------------------------------------------
-int StringConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::StringMessage::Pointer* dest)
+int StringConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::StringMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   if (dest->IsNull())
     *dest = igtl::StringMessage::New();
   igtl::StringMessage::Pointer msg = *dest;
 
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
-  HeadertoIGTL(header, &basemsg);
+  HeadertoIGTL(header, &basemsg, metaInfo);
 
   msg->SetString(source.string_msg);
   msg->SetEncoding(source.encoding);

--- a/Converter/igtlioStringConverter.h
+++ b/Converter/igtlioStringConverter.h
@@ -24,8 +24,8 @@ public:
   static const char*  GetIGTLName() { return GetIGTLTypeName(); }
   static const char* GetIGTLTypeName() { return "STRING"; }
 
-  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC);
-  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::StringMessage::Pointer* dest);
+  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::StringMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
 
 };
 

--- a/Converter/igtlioTransformConverter.cxx
+++ b/Converter/igtlioTransformConverter.cxx
@@ -125,7 +125,8 @@ int TransformConverter::toIGTL(const HeaderData& header, const ContentData& sour
   if (dest->IsNull())
     *dest = igtl::TransformMessage::New();
   igtl::TransformMessage::Pointer msg = *dest;
-
+  if (metaInfo!=NULL)
+    msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
   HeadertoIGTL(header, &basemsg, metaInfo);
   TransformMetaDataToIGTL(source, &basemsg);

--- a/Converter/igtlioTransformConverter.cxx
+++ b/Converter/igtlioTransformConverter.cxx
@@ -124,6 +124,7 @@ int TransformConverter::toIGTL(const HeaderData& header, const ContentData& sour
 {
   if (dest->IsNull())
     *dest = igtl::TransformMessage::New();
+  (*dest)->InitPack();  
   igtl::TransformMessage::Pointer msg = *dest;
   if (metaInfo!=NULL)
     msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);

--- a/Converter/igtlioTransformConverter.cxx
+++ b/Converter/igtlioTransformConverter.cxx
@@ -26,7 +26,7 @@ static std::string stream_id_from_name = "STREAM_ID_FROM";
 int TransformConverter::fromIGTL(igtl::MessageBase::Pointer source,
                              HeaderData* header,
                              ContentData* dest,
-                             bool checkCRC)
+                             bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo)
 {
     // Create a message buffer to receive image data
     igtl::TransformMessage::Pointer transMsg;
@@ -44,7 +44,7 @@ int TransformConverter::fromIGTL(igtl::MessageBase::Pointer source,
       }
 
 	// get header
-	if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(transMsg), header))
+	if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(transMsg), header, metaInfo))
 	  return 0;
 
 	// get additional transform header info
@@ -120,14 +120,14 @@ int TransformConverter::IGTLHeaderToTransformInfo(igtl::MessageBase::Pointer sou
 }
 
 //---------------------------------------------------------------------------
-int TransformConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::TransformMessage::Pointer* dest)
+int TransformConverter::toIGTL(const HeaderData& header, const ContentData& source, igtl::TransformMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo)
 {
   if (dest->IsNull())
     *dest = igtl::TransformMessage::New();
   igtl::TransformMessage::Pointer msg = *dest;
 
   igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
-  HeadertoIGTL(header, &basemsg);
+  HeadertoIGTL(header, &basemsg, metaInfo);
   TransformMetaDataToIGTL(source, &basemsg);
 
   if (source.transform.Get()==NULL)

--- a/Converter/igtlioTransformConverter.h
+++ b/Converter/igtlioTransformConverter.h
@@ -47,8 +47,8 @@ public:
   static const char*  GetIGTLName() { return GetIGTLTypeName(); };
   static const char* GetIGTLTypeName() { return "TRANSFORM"; };
 
-  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC);
-  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::TransformMessage::Pointer* dest);
+  static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
+  static int toIGTL(const HeaderData& header, const ContentData& source, igtl::TransformMessage::Pointer* dest, igtl::MessageBase::MetaDataMap* metaInfo = NULL);
 
   static int IGTLToVTKTransform(const igtl::Matrix4x4& igtlTransform, vtkSmartPointer<vtkMatrix4x4> vtkTransform);
   static int VTKToIGTLTransform(const vtkMatrix4x4& vtkTransform, igtl::Matrix4x4& igtlTransform);

--- a/Devices/igtlioCommandDevice.cxx
+++ b/Devices/igtlioCommandDevice.cxx
@@ -40,12 +40,9 @@ CommandDevice::~CommandDevice()
 }
 
 //---------------------------------------------------------------------------
-vtkIntArray* CommandDevice::GetDeviceContentModifiedEvent() const
+unsigned int CommandDevice::GetDeviceContentModifiedEvent() const
 {
-  vtkIntArray* events;
-  events = vtkIntArray::New();
-  events->InsertNextValue(CommandModifiedEvent);
-  return events;
+  return CommandModifiedEvent;
 }
   
 //---------------------------------------------------------------------------

--- a/Devices/igtlioCommandDevice.cxx
+++ b/Devices/igtlioCommandDevice.cxx
@@ -62,7 +62,7 @@ int CommandDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool ch
   if (buffer->GetDeviceType()==std::string(CommandConverter::GetIGTLResponseName()))
 	{
 	CommandDevicePointer response = CommandDevicePointer::New();
-	if (!CommandConverter::fromIGTLResponse(buffer, &response->HeaderData, &response->Content, checkCRC))
+	if (!CommandConverter::fromIGTLResponse(buffer, &response->HeaderData, &response->Content, checkCRC, &this->metaInfo))
 	  return 0;
 
 	// search among the queries for a command with an identical ID:
@@ -85,7 +85,7 @@ int CommandDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool ch
   //     No response is created - this is the responsibility of the application.
   if (buffer->GetDeviceType()==std::string(CommandConverter::GetIGTLTypeName()))
 	{
-	if (CommandConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC))
+	if (CommandConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, &this->metaInfo))
 	  {
 	  this->Modified();
 	  this->InvokeEvent(CommandReceivedEvent);
@@ -107,7 +107,7 @@ igtl::MessageBase::Pointer CommandDevice::GetIGTLMessage()
 
  this->SetTimestamp(vtkTimerLog::GetUniversalTime());
 
- if (!CommandConverter::toIGTL(HeaderData, Content, &this->OutMessage))
+ if (!CommandConverter::toIGTL(HeaderData, Content, &this->OutMessage, &this->metaInfo))
    {
    return 0;
    }
@@ -145,7 +145,7 @@ igtl::MessageBase::Pointer CommandDevice::GetIGTLResponseMessage()
    this->ResponseMessage = igtl::RTSCommandMessage::New();
 
  igtl::CommandMessage::Pointer response = dynamic_pointer_cast<igtl::CommandMessage>(this->ResponseMessage);
- if (!CommandConverter::toIGTL(HeaderData, Content, &response))
+ if (!CommandConverter::toIGTL(HeaderData, Content, &response, &this->metaInfo))
    {
    return 0;
    }

--- a/Devices/igtlioCommandDevice.h
+++ b/Devices/igtlioCommandDevice.h
@@ -29,7 +29,7 @@ public:
   vtkSetMacro( QueryTimeOut, double );
   vtkGetMacro( QueryTimeOut, double );
 
- virtual vtkIntArray* GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
+ virtual unsigned int GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
  virtual std::string GetDeviceType() const VTK_OVERRIDE;
  virtual int ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC) VTK_OVERRIDE;
  virtual igtl::MessageBase::Pointer GetIGTLMessage() VTK_OVERRIDE;

--- a/Devices/igtlioDevice.cxx
+++ b/Devices/igtlioDevice.cxx
@@ -52,16 +52,43 @@ const igtl::MessageBase::MetaDataMap& Device::GetMetaData() const
   return this->metaInfo;
 }
 
-void Device::SetMetaData(const igtl::MessageBase::MetaDataMap& sourceMetaInfo)
+void Device::ClearMetaData()
 {
-  metaInfo.clear();
-  for (igtl::MessageBase::MetaDataMap::const_iterator it = sourceMetaInfo.begin(); it != sourceMetaInfo.end(); ++it)
+  this->metaInfo.clear();
+}
+
+  
+bool Device::SetMetaDataElement(const std::string& key, IANA_ENCODING_TYPE encodingScheme, std::string value)
+{
+  igtl_metadata_header_entry entry;
+  if (key.length() > std::numeric_limits<igtl_uint16>::max())
     {
-    std::string key = it->first;
-    IANA_ENCODING_TYPE encodingScheme = it->second.first;
-    std::string value = it->second.second;
-    metaInfo[key] = std::pair<IANA_ENCODING_TYPE, std::string>(encodingScheme, value);
+    return false;
     }
+  entry.key_size = static_cast<igtl_uint16>(key.length());
+  entry.value_encoding = static_cast<igtlUint16>(encodingScheme);
+  entry.value_size = value.length();
+
+  metaInfo[key] = std::pair<IANA_ENCODING_TYPE, std::string>(encodingScheme, value);
+  return true;
+}
+
+bool Device::GetMetaDataElement(const std::string& key, std::string& value) const
+{
+  IANA_ENCODING_TYPE type;
+  return GetMetaDataElement(key, type, value);
+}
+
+bool Device::GetMetaDataElement(const std::string& key, IANA_ENCODING_TYPE& encoding, std::string& value) const
+{
+  if (this->metaInfo.find(key) != this->metaInfo.end())
+    {
+    encoding = this->metaInfo.find(key)->second.first;
+    value = this->metaInfo.find(key)->second.second;
+    return true;
+    }
+
+  return false;
 }
 
 unsigned int Device::GetDeviceContentModifiedEvent() const

--- a/Devices/igtlioDevice.cxx
+++ b/Devices/igtlioDevice.cxx
@@ -64,12 +64,9 @@ void Device::SetMetaData(const igtl::MessageBase::MetaDataMap& sourceMetaInfo)
     }
 }
 
-vtkIntArray* Device::GetDeviceContentModifiedEvent() const
+unsigned int Device::GetDeviceContentModifiedEvent() const
 {
-  vtkIntArray* events;
-  events = vtkIntArray::New();
-  events->InsertNextValue(vtkCommand::ModifiedEvent);
-  return events;
+  return vtkCommand::ModifiedEvent;
 }
   
   

--- a/Devices/igtlioDevice.cxx
+++ b/Devices/igtlioDevice.cxx
@@ -47,6 +47,23 @@ std::string Device::GetDeviceType() const
   return NULL;
 }
 
+const igtl::MessageBase::MetaDataMap& Device::GetMetaData() const
+{
+  return this->metaInfo;
+}
+
+void Device::SetMetaData(const igtl::MessageBase::MetaDataMap& sourceMetaInfo)
+{
+  metaInfo.clear();
+  for (igtl::MessageBase::MetaDataMap::const_iterator it = sourceMetaInfo.begin(); it != sourceMetaInfo.end(); ++it)
+    {
+    std::string key = it->first;
+    IANA_ENCODING_TYPE encodingScheme = it->second.first;
+    std::string value = it->second.second;
+    metaInfo[key] = std::pair<IANA_ENCODING_TYPE, std::string>(encodingScheme, value);
+    }
+}
+
 vtkIntArray* Device::GetDeviceContentModifiedEvent() const
 {
   vtkIntArray* events;

--- a/Devices/igtlioDevice.h
+++ b/Devices/igtlioDevice.h
@@ -116,8 +116,23 @@ public:
  // Return Meta information
  const igtl::MessageBase::MetaDataMap& GetMetaData() const;
  
- // Copy the source meta information. 
- void SetMetaData(const igtl::MessageBase::MetaDataMap& sourceMetaInfo);
+ /// Add Meta data element
+ bool SetMetaDataElement(const std::string& key, IANA_ENCODING_TYPE encodingScheme, std::string value);
+
+ template <class dataType>
+ bool SetMetaDataElement(const std::string& key, dataType value)
+ {
+   std::stringstream ss;
+   ss << value;
+   return SetMetaDataElement(key, IANA_TYPE_US_ASCII, ss.str());
+ }
+ 
+ /// Get meta data element
+ bool GetMetaDataElement(const std::string& key, std::string& value) const;
+ bool GetMetaDataElement(const std::string& key, IANA_ENCODING_TYPE& encoding, std::string& value) const;
+ 
+ /// Clear all data elements
+ void ClearMetaData();
 
 public:
   vtkAbstractTypeMacro(Device,vtkObject);

--- a/Devices/igtlioDevice.h
+++ b/Devices/igtlioDevice.h
@@ -112,7 +112,12 @@ public:
  // TODO: add old features from Connector:
  //       - lock (means dont accept incoming messages),
  //       - gettimestamp (of last incoming message)
-
+ 
+ // Return Meta information
+ const igtl::MessageBase::MetaDataMap& GetMetaData() const;
+ 
+ // Copy the source meta information. 
+ void SetMetaData(const igtl::MessageBase::MetaDataMap& sourceMetaInfo);
 
 public:
   vtkAbstractTypeMacro(Device,vtkObject);
@@ -121,6 +126,8 @@ protected:
   void SetHeader(BaseConverter::HeaderData header);
 
   BaseConverter::HeaderData HeaderData;
+  
+  igtl::MessageBase::MetaDataMap metaInfo;
 
 protected:
  Device();

--- a/Devices/igtlioDevice.h
+++ b/Devices/igtlioDevice.h
@@ -64,7 +64,7 @@ public:
 
 public:
  
- virtual vtkIntArray* GetDeviceContentModifiedEvent() const;
+ virtual unsigned int GetDeviceContentModifiedEvent() const;
   
  virtual std::string GetDeviceType() const;
 

--- a/Devices/igtlioImageDevice.cxx
+++ b/Devices/igtlioImageDevice.cxx
@@ -83,7 +83,7 @@ ImageConverter::ContentData ImageDevice::GetContent()
 //---------------------------------------------------------------------------
 int ImageDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (ImageConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC))
+ if (ImageConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, &this->metaInfo))
    {
    this->Modified();
    this->InvokeEvent(ImageModifiedEvent, this);
@@ -104,7 +104,7 @@ igtl::MessageBase::Pointer ImageDevice::GetIGTLMessage()
   return 0;
   }
 
- if (!ImageConverter::toIGTL(HeaderData, Content, &this->OutImageMessage))
+ if (!ImageConverter::toIGTL(HeaderData, Content, &this->OutImageMessage, &this->metaInfo))
    {
    return 0;
    }

--- a/Devices/igtlioImageDevice.cxx
+++ b/Devices/igtlioImageDevice.cxx
@@ -52,12 +52,9 @@ ImageDevice::~ImageDevice()
 }
 
 //---------------------------------------------------------------------------
-vtkIntArray* ImageDevice::GetDeviceContentModifiedEvent() const
+unsigned int ImageDevice::GetDeviceContentModifiedEvent() const
 {
-  vtkIntArray* events;
-  events = vtkIntArray::New();
-  events->InsertNextValue(ImageModifiedEvent);
-  return events;
+  return ImageModifiedEvent;
 }
   
   

--- a/Devices/igtlioImageDevice.h
+++ b/Devices/igtlioImageDevice.h
@@ -37,7 +37,7 @@ public:
     ImageModifiedEvent         = 118955,
   };
   
- virtual vtkIntArray* GetDeviceContentModifiedEvent() const VTK_OVERRIDE ;
+ virtual unsigned int GetDeviceContentModifiedEvent() const VTK_OVERRIDE ;
  virtual std::string GetDeviceType() const VTK_OVERRIDE;
  virtual int ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC) VTK_OVERRIDE;
  virtual igtl::MessageBase::Pointer GetIGTLMessage() VTK_OVERRIDE;

--- a/Devices/igtlioPolyDataDevice.cxx
+++ b/Devices/igtlioPolyDataDevice.cxx
@@ -69,7 +69,7 @@ std::string PolyDataDevice::GetDeviceType() const
 //---------------------------------------------------------------------------
 int PolyDataDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (PolyDataConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC))
+ if (PolyDataConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, &this->metaInfo))
  {
    this->Modified();
    this->InvokeEvent(ReceiveEvent);
@@ -90,7 +90,7 @@ igtl::MessageBase::Pointer PolyDataDevice::GetIGTLMessage()
   }
   */
 
- if (!PolyDataConverter::toIGTL(HeaderData, Content, &this->OutMessage))
+ if (!PolyDataConverter::toIGTL(HeaderData, Content, &this->OutMessage, &this->metaInfo))
    {
    return 0;
    }

--- a/Devices/igtlioPolyDataDevice.cxx
+++ b/Devices/igtlioPolyDataDevice.cxx
@@ -73,6 +73,7 @@ int PolyDataDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool c
  {
    this->Modified();
    this->InvokeEvent(ReceiveEvent);
+   this->InvokeEvent(PolyDataModifiedEvent, this);
    return 1;
  }
 
@@ -122,6 +123,7 @@ void PolyDataDevice::SetContent(PolyDataConverter::ContentData content)
 {
   Content = content;
   this->Modified();
+  this->InvokeEvent(PolyDataModifiedEvent, this);
 }
 
 PolyDataConverter::ContentData PolyDataDevice::GetContent()

--- a/Devices/igtlioPolyDataDevice.cxx
+++ b/Devices/igtlioPolyDataDevice.cxx
@@ -52,12 +52,9 @@ PolyDataDevice::~PolyDataDevice()
 }
 
 //---------------------------------------------------------------------------
-vtkIntArray* PolyDataDevice::GetDeviceContentModifiedEvent() const
+unsigned int PolyDataDevice::GetDeviceContentModifiedEvent() const
 {
-  vtkIntArray* events;
-  events = vtkIntArray::New();
-  events->InsertNextValue(PolyDataModifiedEvent);
-  return events;
+  return PolyDataModifiedEvent;
 }
 
 //---------------------------------------------------------------------------

--- a/Devices/igtlioPolyDataDevice.h
+++ b/Devices/igtlioPolyDataDevice.h
@@ -34,7 +34,7 @@ public:
     PolyDataModifiedEvent         = 118959,
   };
   
- virtual vtkIntArray* GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
+ virtual unsigned int GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
  virtual std::string GetDeviceType() const VTK_OVERRIDE;
  virtual int ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC) VTK_OVERRIDE;
  virtual igtl::MessageBase::Pointer GetIGTLMessage() VTK_OVERRIDE;

--- a/Devices/igtlioStatusDevice.cxx
+++ b/Devices/igtlioStatusDevice.cxx
@@ -38,12 +38,9 @@ StatusDevice::~StatusDevice()
 }
 
 //---------------------------------------------------------------------------
-vtkIntArray* StatusDevice::GetDeviceContentModifiedEvent() const
+unsigned int StatusDevice::GetDeviceContentModifiedEvent() const
 {
-  vtkIntArray* events;
-  events = vtkIntArray::New();
-  events->InsertNextValue(StatusModifiedEvent);
-  return events;
+  return StatusModifiedEvent;
 }
 
 //---------------------------------------------------------------------------

--- a/Devices/igtlioStatusDevice.cxx
+++ b/Devices/igtlioStatusDevice.cxx
@@ -55,7 +55,7 @@ std::string StatusDevice::GetDeviceType() const
 //---------------------------------------------------------------------------
 int StatusDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (StatusConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC))
+ if (StatusConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, &this->metaInfo))
  {
    this->Modified();
    this->InvokeEvent(StatusModifiedEvent, this);
@@ -77,7 +77,7 @@ igtl::MessageBase::Pointer StatusDevice::GetIGTLMessage()
   }
   */
 
- if (!StatusConverter::toIGTL(HeaderData, Content, &this->OutMessage))
+ if (!StatusConverter::toIGTL(HeaderData, Content, &this->OutMessage, &this->metaInfo))
    {
    return 0;
    }

--- a/Devices/igtlioStatusDevice.h
+++ b/Devices/igtlioStatusDevice.h
@@ -18,7 +18,7 @@ public:
     StatusModifiedEvent         = 118956,
   };
   
- virtual vtkIntArray* GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
+ virtual unsigned int GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
  virtual std::string GetDeviceType() const VTK_OVERRIDE;
  virtual int ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC) VTK_OVERRIDE;
  virtual igtl::MessageBase::Pointer GetIGTLMessage() VTK_OVERRIDE;

--- a/Devices/igtlioStringDevice.cxx
+++ b/Devices/igtlioStringDevice.cxx
@@ -46,7 +46,7 @@ std::string StringDevice::GetDeviceType() const
 //---------------------------------------------------------------------------
 int StringDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (StringConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC))
+ if (StringConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, &this->metaInfo))
  {
    this->Modified();
    this->InvokeEvent(ReceiveEvent);
@@ -60,7 +60,7 @@ int StringDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool che
 igtl::MessageBase::Pointer StringDevice::GetIGTLMessage()
 {
 
- if (!StringConverter::toIGTL(HeaderData, Content, &this->OutMessage))
+ if (!StringConverter::toIGTL(HeaderData, Content, &this->OutMessage, &this->metaInfo))
    {
    return 0;
    }

--- a/Devices/igtlioStringDevice.cxx
+++ b/Devices/igtlioStringDevice.cxx
@@ -44,12 +44,22 @@ std::string StringDevice::GetDeviceType() const
 }
 
 //---------------------------------------------------------------------------
+vtkIntArray* StringDevice::GetDeviceContentModifiedEvent() const
+{
+  vtkIntArray* events;
+  events = vtkIntArray::New();
+  events->InsertNextValue(StringModifiedEvent);
+  return events;
+}
+
+//---------------------------------------------------------------------------
 int StringDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
  if (StringConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, &this->metaInfo))
  {
    this->Modified();
    this->InvokeEvent(ReceiveEvent);
+   this->InvokeEvent(StringModifiedEvent, this);
    return 1;
  }
 
@@ -91,6 +101,7 @@ void StringDevice::SetContent(StringConverter::ContentData content)
 {
   Content = content;
   this->Modified();
+  this->InvokeEvent(StringModifiedEvent, this);
 }
 
 StringConverter::ContentData StringDevice::GetContent()

--- a/Devices/igtlioStringDevice.cxx
+++ b/Devices/igtlioStringDevice.cxx
@@ -44,12 +44,9 @@ std::string StringDevice::GetDeviceType() const
 }
 
 //---------------------------------------------------------------------------
-vtkIntArray* StringDevice::GetDeviceContentModifiedEvent() const
+unsigned int StringDevice::GetDeviceContentModifiedEvent() const
 {
-  vtkIntArray* events;
-  events = vtkIntArray::New();
-  events->InsertNextValue(StringModifiedEvent);
-  return events;
+  return StringModifiedEvent;
 }
 
 //---------------------------------------------------------------------------

--- a/Devices/igtlioStringDevice.h
+++ b/Devices/igtlioStringDevice.h
@@ -15,6 +15,11 @@ typedef vtkSmartPointer<class StringDevice> StringDevicePointer;
 class OPENIGTLINKIO_DEVICES_EXPORT StringDevice : public Device
 {
 public:
+  enum {
+    StringModifiedEvent         = 118960,
+  };
+  
+ virtual vtkIntArray* GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
  virtual std::string GetDeviceType() const VTK_OVERRIDE;
  virtual int ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC) VTK_OVERRIDE;
  virtual igtl::MessageBase::Pointer GetIGTLMessage() VTK_OVERRIDE;

--- a/Devices/igtlioStringDevice.h
+++ b/Devices/igtlioStringDevice.h
@@ -19,7 +19,7 @@ public:
     StringModifiedEvent         = 118960,
   };
   
- virtual vtkIntArray* GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
+ virtual unsigned int GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
  virtual std::string GetDeviceType() const VTK_OVERRIDE;
  virtual int ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC) VTK_OVERRIDE;
  virtual igtl::MessageBase::Pointer GetIGTLMessage() VTK_OVERRIDE;

--- a/Devices/igtlioTransformDevice.cxx
+++ b/Devices/igtlioTransformDevice.cxx
@@ -51,12 +51,9 @@ TransformDevice::~TransformDevice()
 }
 
 //---------------------------------------------------------------------------
-vtkIntArray* TransformDevice::GetDeviceContentModifiedEvent() const
+unsigned int TransformDevice::GetDeviceContentModifiedEvent() const
 {
-  vtkIntArray* events;
-  events = vtkIntArray::New();
-  events->InsertNextValue(TransformModifiedEvent);
-  return events;
+  return TransformModifiedEvent;
 }
 
 //---------------------------------------------------------------------------

--- a/Devices/igtlioTransformDevice.cxx
+++ b/Devices/igtlioTransformDevice.cxx
@@ -81,7 +81,7 @@ TransformConverter::ContentData TransformDevice::GetContent()
 //---------------------------------------------------------------------------
 int TransformDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (TransformConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC))
+ if (TransformConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, &this->metaInfo))
  {
    this->Modified();
    this->InvokeEvent(TransformModifiedEvent, this);
@@ -102,7 +102,7 @@ igtl::MessageBase::Pointer TransformDevice::GetIGTLMessage()
   return 0;
   }
 
- if (!TransformConverter::toIGTL(HeaderData, Content, &this->OutTransformMessage))
+ if (!TransformConverter::toIGTL(HeaderData, Content, &this->OutTransformMessage, &this->metaInfo))
    {
    return 0;
    }

--- a/Devices/igtlioTransformDevice.h
+++ b/Devices/igtlioTransformDevice.h
@@ -34,7 +34,7 @@ public:
     TransformModifiedEvent         = 118957,
   };
   
-virtual vtkIntArray* GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
+ virtual unsigned int GetDeviceContentModifiedEvent() const VTK_OVERRIDE;
  virtual std::string GetDeviceType() const VTK_OVERRIDE;
  virtual int ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC) VTK_OVERRIDE;
  virtual igtl::MessageBase::Pointer GetIGTLMessage() VTK_OVERRIDE;

--- a/GUI/qIGTLIODevicesModel.cxx
+++ b/GUI/qIGTLIODevicesModel.cxx
@@ -255,7 +255,7 @@ void qIGTLIODevicesModel::ReconnectConnector(igtlio::Connector* oldConnector, ig
           << igtlio::Connector::ActivatedEvent
           << igtlio::Connector::DeactivatedEvent
           << igtlio::Connector::NewDeviceEvent
-          << igtlio::Connector::DeviceModifiedEvent
+          << igtlio::Connector::DeviceContentModifiedEvent
           << igtlio::Connector::RemovedDeviceEvent
           )
     {
@@ -307,7 +307,7 @@ void qIGTLIODevicesModel::onConnectorEvent(vtkObject* caller, unsigned long even
      this->beginRemoveRows(parent, node->GetSiblingIndex(), node->GetSiblingIndex());
      this->endRemoveRows();
     }
-  if (event==igtlio::Connector::DeviceModifiedEvent)
+  if (event==igtlio::Connector::DeviceContentModifiedEvent)
     {
       // TODO: this event is never emittd, and never will. The vtkCommand::ModifiedEvent is emitted
       // from each device, and each of the must be listened to.

--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -718,23 +718,19 @@ int Connector::AddDevice(DevicePointer device)
   device->SetTimestamp(vtkTimerLog::GetUniversalTime());
   Devices.push_back(device);
   //TODO: listen to device events?
-  vtkIntArray* deviceEvents = device->GetDeviceContentModifiedEvent();
-  device->AddObserver((unsigned long)(deviceEvents->GetValue(0)), this, &Connector::DeviceModified);
+  unsigned int deviceEvent = device->GetDeviceContentModifiedEvent();
+  device->AddObserver((unsigned long)deviceEvent, this, &Connector::DeviceContentModified);
   this->InvokeEvent(Connector::NewDeviceEvent, device.GetPointer());
   return 1;
 }
 
 
-void Connector::DeviceModified(vtkObject *caller, unsigned long event, void *callData )
+void Connector::DeviceContentModified(vtkObject *caller, unsigned long event, void *callData )
 {
   igtlio::Device* modifiedDevice = reinterpret_cast<igtlio::Device*>(callData);
   if (modifiedDevice)
     {
-    if(modifiedDevice->MessageDirectionIsOut())
-      {
-      this->PushNode(modifiedDevice);
-      }
-    this->InvokeEvent(Connector::DeviceModifiedEvent, modifiedDevice);
+    this->InvokeEvent(Connector::DeviceContentModifiedEvent, modifiedDevice);
     }
 }
 

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -111,7 +111,7 @@ public:
  /// Get the given Device. This can be used to modify the Device contents.
  
  /// invoke event if device content modified
- void DeviceModified(vtkObject *caller, unsigned long event, void *callData );
+ void DeviceContentModified(vtkObject *caller, unsigned long event, void *callData );
  DevicePointer GetDevice(int index);
  DevicePointer GetDevice(DeviceKeyType key);
  bool HasDevice( DevicePointer d );
@@ -133,7 +133,7 @@ public:
     DeactivatedEvent      = 118947,
 //    ReceiveEvent          = 118948,
     NewDeviceEvent        = 118949,
-    DeviceModifiedEvent   = 118950, // invoked by the devices
+    DeviceContentModifiedEvent   = 118950, // invoked by the devices
     RemovedDeviceEvent    = 118951,
   };
 

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -109,6 +109,9 @@ public:
  void RemoveDevice(int index); //TODO: look at OnNodeReferenceRemoved
   int RemoveDevice(DevicePointer device);
  /// Get the given Device. This can be used to modify the Device contents.
+ 
+ /// invoke event if device content modified
+ void DeviceModified(vtkObject *caller, unsigned long event, void *callData );
  DevicePointer GetDevice(int index);
  DevicePointer GetDevice(DeviceKeyType key);
  bool HasDevice( DevicePointer d );
@@ -130,7 +133,7 @@ public:
     DeactivatedEvent      = 118947,
 //    ReceiveEvent          = 118948,
     NewDeviceEvent        = 118949,
-    DeviceModifiedEvent   = 118950, // never used. use vtkCommand::ModifiedEvent from device instead.
+    DeviceModifiedEvent   = 118950, // invoked by the devices
     RemovedDeviceEvent    = 118951,
   };
 


### PR DESCRIPTION
Hi All,
@lassoan , @jbake , @olevs 
I just made the adding of meta information generalized.  
The device now have a function SetMetaData for inserting meta information.
For example, the equipment type meta information could be set at the application level using the following lines:

igtl::MessageBase::MetaDataMap souceMetaInfo;
souceMetaInfo[equipment_uid_name] = std::pair<IANA_ENCODING_TYPE, std::string>(IANA_TYPE_US_ASCII,header.equipmentId );
souceMetaInfo[stream_id_name] = std::pair<IANA_ENCODING_TYPE, std::string>(IANA_TYPE_US_ASCII,header.streamId );
souceMetaInfo[equipment_type_name] = std::pair<IANA_ENCODING_TYPE, std::string>(IANA_TYPE_US_ASCII,header.equipmentType );
device->SetMetaData(souceMetaInfo);

Do you think it is a good idea?
I am open to any suggestions.

Best Regards,
Longquan
