### PR TITLE
EHN: Connector should invokes the device event id from the device.

### DIFF
--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -730,7 +730,7 @@ void Connector::DeviceContentModified(vtkObject *caller, unsigned long event, vo
   igtlio::Device* modifiedDevice = reinterpret_cast<igtlio::Device*>(callData);
   if (modifiedDevice)
     {
-    this->InvokeEvent(Connector::DeviceContentModifiedEvent, modifiedDevice);
+    this->InvokeEvent(modifiedDevice->GetDeviceContentModifiedEvent(), modifiedDevice);
     }
 }
 

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -133,7 +133,7 @@ public:
     DeactivatedEvent      = 118947,
 //    ReceiveEvent          = 118948,
     NewDeviceEvent        = 118949,
-    DeviceContentModifiedEvent   = 118950, // invoked by the devices
+    //DeviceContentModifiedEvent   = 118950, // invoked by the devices
     RemovedDeviceEvent    = 118951,
   };
 

--- a/Logic/igtlioLogic.cxx
+++ b/Logic/igtlioLogic.cxx
@@ -38,6 +38,7 @@ void onNewDeviceEventFunc(vtkObject* caller, unsigned long eid, void* clientdata
 
   Device* device = reinterpret_cast<Device*>(calldata);
   device->AddObserver(Device::CommandReceivedEvent, logic->DeviceEventCallback);
+  device->AddObserver(device->GetDeviceContentModifiedEvent(), logic->DeviceEventCallback);
   device->AddObserver(Device::CommandResponseReceivedEvent, logic->DeviceEventCallback);
 }
 
@@ -55,8 +56,9 @@ void onRemovedDeviceEventFunc(vtkObject* caller, unsigned long eid, void* client
 void onDeviceEventFunc(vtkObject* caller, unsigned long eid, void* clientdata, void *calldata)
 {
   Logic* logic = reinterpret_cast<Logic*>(clientdata);
-
+  Device* device = reinterpret_cast<Device*>(caller);
   if ((eid==Device::CommandReceivedEvent) ||
+      (eid==device->GetDeviceContentModifiedEvent()) ||
       (eid==Device::CommandResponseReceivedEvent))
   {
     logic->InvokeEvent(eid, calldata);


### PR DESCRIPTION
hi Adam,

Should the connector invokes the modified event from the devices
or invokes a custom event "Connector::DeviceContentModifiedEvent"?
Any comments?

This merge will invoke the modified event from the devices.

Best,
Longquan