### PR TITLE
Small interface addition

### DIFF
--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -467,8 +467,11 @@ int Connector::ReceiveController()
       vtkDebugMacro("Received body: " << read);
       if (read != buffer->GetPackBodySize())
         {
-        vtkErrorMacro ("Only read " << read << " but expected to read "
-                       << buffer->GetPackBodySize() << "\n");
+        if(!this->ServerStopFlag)
+        {
+          vtkErrorMacro ("Only read " << read << " but expected to read "
+                         << buffer->GetPackBodySize() << "\n");
+        }
         continue;
         }
 

--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -845,4 +845,9 @@ int Connector::PushNode(DevicePointer node, int event)
   return this->SendMessage(CreateDeviceKey(node), Device::MESSAGE_PREFIX_NOT_DEFINED);
 }
 
+bool Connector::IsConnected()
+{
+  return this->Socket.IsNotNull() && this->Socket->GetConnected();
+}
+
 } // namespace igtlio

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -221,6 +221,8 @@ public:
   vtkGetMacro( CheckCRC, bool);
   void SetCheckCRC(bool c);
 
+  bool IsConnected();
+
   //----------------------------------------------------------------
   // Thread Control
   //----------------------------------------------------------------

--- a/Logic/igtlioLogic.cxx
+++ b/Logic/igtlioLogic.cxx
@@ -131,6 +131,25 @@ int Logic::RemoveConnector(unsigned int index)
 {
   std::vector<ConnectorPointer>::iterator toRemove = Connectors.begin()+index;
 
+  return this->RemoveConnector(toRemove);
+}
+
+//---------------------------------------------------------------------------
+int Logic::RemoveConnector(ConnectorPointer connector)
+{
+
+  std::vector<ConnectorPointer>::iterator toRemove = Connectors.begin();
+  for(; toRemove != Connectors.end(); ++toRemove)
+  {
+    if(connector == (*toRemove))
+      break;
+  }
+  return this->RemoveConnector(toRemove);
+}
+
+//---------------------------------------------------------------------------
+int Logic::RemoveConnector(std::vector<ConnectorPointer>::iterator toRemove)
+{
   toRemove->GetPointer()->RemoveObserver(NewDeviceCallback);
   toRemove->GetPointer()->RemoveObserver(RemovedDeviceCallback);
 
@@ -138,6 +157,7 @@ int Logic::RemoveConnector(unsigned int index)
   Connectors.erase(toRemove);
   return 0;
 }
+
 
 //---------------------------------------------------------------------------
 int Logic::GetNumberOfConnectors() const

--- a/Logic/igtlioLogic.cxx
+++ b/Logic/igtlioLogic.cxx
@@ -150,12 +150,15 @@ int Logic::RemoveConnector(ConnectorPointer connector)
 //---------------------------------------------------------------------------
 int Logic::RemoveConnector(std::vector<ConnectorPointer>::iterator toRemove)
 {
+  if(toRemove == Connectors.end())
+    return 0;
+
   toRemove->GetPointer()->RemoveObserver(NewDeviceCallback);
   toRemove->GetPointer()->RemoveObserver(RemovedDeviceCallback);
 
   this->InvokeEvent(ConnectionAboutToBeRemovedEvent, toRemove->GetPointer());
   Connectors.erase(toRemove);
-  return 0;
+  return 1;
 }
 
 

--- a/Logic/igtlioLogic.h
+++ b/Logic/igtlioLogic.h
@@ -73,6 +73,7 @@ public:
 
  ConnectorPointer CreateConnector();
  int RemoveConnector(unsigned int index);
+ int RemoveConnector(ConnectorPointer connector);
  int GetNumberOfConnectors() const;
  ConnectorPointer GetConnector(unsigned int index);
 
@@ -107,6 +108,7 @@ private:
 
   int CreateUniqueConnectorID() const;
   std::vector<DevicePointer> CreateDeviceList() const;
+  int RemoveConnector(std::vector<ConnectorPointer>::iterator toRemove);
 
   vtkSmartPointer<class vtkCallbackCommand> NewDeviceCallback;
   vtkSmartPointer<class vtkCallbackCommand> RemovedDeviceCallback;


### PR DESCRIPTION
We need a simple way to remove connectors from code, and not only from the GUI widget, so I added Logic::RemoveConnector(ConnectorPointer connector).

I also removed an error message we get when stopping the Connector.