### PR TITLE
BUG: Commands sent using Connector::SendCommand() always have id of 1

### DIFF
--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -689,7 +689,7 @@ CommandDevicePointer Connector::SendCommand(std::string device_id, std::string c
   vtkSmartPointer<CommandDevice> device = CommandDevice::SafeDownCast( AddDeviceIfNotPresent(key) );
 
   igtlio::CommandConverter::ContentData contentdata = device->GetContent();
-  contentdata.id +=1;
+  contentdata.id = this->CommandId;
   contentdata.name = command;
   contentdata.content = content;
   device->SetContent(contentdata);
@@ -697,6 +697,8 @@ CommandDevicePointer Connector::SendCommand(std::string device_id, std::string c
   device->PruneCompletedQueries();
 
   SendMessage(CreateDeviceKey(device));
+
+  ++this->CommandId;
 
   return device;
 }

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -345,6 +345,8 @@ private:
 
   bool CheckCRC;
 
+  int CommandId = 0;
+
 };
 
 } // namespace  igtlio


### PR DESCRIPTION
* All commands sent had an id of 1 (Struct default 0+1)
* Fixed by storing the current command id in the connector, which is incremented after every command