### PR TITLE
ENH: Move command processing to queue outside of circular buffer and add command timeout argument

### DIFF
--- a/Devices/igtlioCommandDevice.cxx
+++ b/Devices/igtlioCommandDevice.cxx
@@ -69,6 +69,7 @@ int CommandDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool ch
 	  if (query && query->GetContent().id == response->GetContent().id)
 		{
 		Queries[i].Response = response;
+		Queries[i].status = QUERY_STATUS_SUCCESS;
 		this->Modified();
 		this->InvokeEvent(CommandResponseReceivedEvent, this);
 		}


### PR DESCRIPTION
- Command arguments are now dealt with in a queue, separate from the circular buffer.
- The SendCommand function now accepts a timeout parameter
- When a command response is received, the query status is set to QUERY_STATUS_SUCCESS so that it can be pruned from the query list.