### PR TITLE
BUG: Fix SectionBuffer memory leak

### DIFF
--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -442,7 +442,7 @@ int Connector::ReceiveController()
     if (iter == this->SectionBuffer.end()) // First time to refer the device name
       {
       this->CircularBufferMutex->Lock();
-      this->SectionBuffer[key] = CircularSectionBuffer::New();
+      this->SectionBuffer[key] = CircularSectionBufferPointer::New();
       this->SectionBuffer[key]->SetPacketMode(igtlio::CircularSectionBuffer::SinglePacketMode);
       if (strcmp(headerMsg->GetDeviceType(), "VIDEO")==0)
         {

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -323,7 +323,7 @@ private:
   //----------------------------------------------------------------
 
 
-  typedef std::map<DeviceKeyType, CircularSectionBuffer*> CircularSectionBufferMap;
+  typedef std::map<DeviceKeyType, CircularSectionBufferPointer> CircularSectionBufferMap;
   CircularSectionBufferMap SectionBuffer;
 
   vtkMutexLockPointer CircularBufferMutex;


### PR DESCRIPTION
CircularSectionBuffers are created and stored in the SectionBuffer, but are never deleted.
Fixed by changing CircularSectionBuffer* to CircularSectionBufferPointer.