### PR TITLE
Allow setting ServerStopFlag in igtlioConnector from the outside.

### DIFF
--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -214,6 +214,8 @@ public:
   vtkSetMacro( Persistent, int );
   vtkGetMacro( Persistent, int );
 
+  vtkSetMacro( ServerStopFlag, int );
+
   const char* GetServerHostname();
   void SetServerHostname(std::string str);
 


### PR DESCRIPTION
This makes it possible to stop the thread without waiting for a locked mutex in Connector::Stop().