### PR TITLE
BUG: Fix double invocation of queued requested events

### DIFF
--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -674,11 +674,11 @@ void Connector::ImportEventsFromEventBuffer()
       eventId=this->EventQueue.front();
       this->EventQueue.pop_front();
       emptyQueue=false;
+
+      // Invoke the event
+      this->InvokeEvent(eventId);
     }
     this->EventQueueMutex->Unlock();
-
-    // Invoke the event
-    this->InvokeEvent(eventId);
 
   } while (!emptyQueue);
 }


### PR DESCRIPTION
The last event in the queue is currently invoked twice.