### PR TITLE
Convenient compilation fix for Video Streaming

### DIFF
--- a/Converter/igtlioVideoConverter.h
+++ b/Converter/igtlioVideoConverter.h
@@ -18,6 +18,7 @@
 
 // OpenIGTLink includes
 #include "igtlVideoMessage.h"
+#include "igtlCodecCommonClasses.h"
 #include "igtlConfigure.h"
 #include "igtl_util.h"
 #if defined(OpenIGTLink_USE_H264)


### PR DESCRIPTION
Can now build the code when video streaming is enabled in OpenIGTLink but none of the codecs are.