### PR TITLE
BUG: Fix Linux and MacOS compile issues from command changes

### DIFF
--- a/Converter/igtlioCommandConverter.cxx
+++ b/Converter/igtlioCommandConverter.cxx
@@ -112,3 +112,26 @@ int igtlioCommandConverter::toIGTL(const HeaderData& header, const ContentData& 
   return 1;
 }
 
+//---------------------------------------------------------------------------
+int igtlioCommandConverter::toIGTLResponse(const HeaderData& header, const ContentData& source, igtl::RTSCommandMessage::Pointer* dest, igtl::MessageBase::MetaDataMap metaInfo)
+{
+  if (dest->IsNull())
+    *dest = igtl::RTSCommandMessage::New();
+  (*dest)->InitPack();
+  igtl::RTSCommandMessage::Pointer msg = *dest;
+
+  if (!metaInfo.empty())
+    {
+    msg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
+    }
+  igtl::MessageBase::Pointer basemsg = dynamic_pointer_cast<igtl::MessageBase>(msg);
+  HeadertoIGTL(header, &basemsg, metaInfo);
+
+  msg->SetCommandId(source.id);
+  msg->SetCommandName(source.name);
+  msg->SetCommandContent(source.content);
+  msg->SetMetaDataElement("Status", IANA_TYPE_US_ASCII, source.status ? "SUCCESS" : "FAIL");
+  msg->Pack();
+
+  return 1;
+}

--- a/Converter/igtlioCommandConverter.h
+++ b/Converter/igtlioCommandConverter.h
@@ -36,6 +36,7 @@ public:
   static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC, igtl::MessageBase::MetaDataMap& outMetaInfo);
   static int fromIGTLResponse(igtl::MessageBase::Pointer source, HeaderData *header, ContentData *dest, bool checkCRC, igtl::MessageBase::MetaDataMap& outMetaInfo);
   static int toIGTL(const HeaderData& header, const ContentData& source, igtl::CommandMessage::Pointer* dest, igtl::MessageBase::MetaDataMap metaInfo = igtl::MessageBase::MetaDataMap());
+  static int toIGTLResponse(const HeaderData& header, const ContentData& source, igtl::RTSCommandMessage::Pointer* dest, igtl::MessageBase::MetaDataMap metaInfo = igtl::MessageBase::MetaDataMap());
 
   static std::vector<std::string> GetAvailableCommandNames();
 };

--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -833,8 +833,7 @@ int igtlioConnector::SendCommandResponse(igtlioCommandPointer command)
   content.content = command->GetResponseContent();
 
   igtl::MessageBase::MetaDataMap metaData = command->GetResponseMetaData();
-  igtl::CommandMessage::Pointer commandMessage = responseMessage;
-  igtlioCommandConverter::toIGTL(headerData, content, &commandMessage, metaData);
+  igtlioCommandConverter::toIGTLResponse(headerData, content, &responseMessage, metaData);
 
   int success = this->SendData(responseMessage->GetPackSize(), (unsigned char*)responseMessage->GetPackPointer());
   command->SetStatus(igtlioCommandStatus::CommandResponseSent);


### PR DESCRIPTION
Add toIGTLResponse to igtlioCommandConverter, mirroring the existence of the fromIGTL and fromIGTLResponse functions

Re #54, https://github.com/openigtlink/SlicerOpenIGTLink/pull/40