### PR TITLE
Moving the ultrasound meta information tag names from PLUS to igtlio.

### DIFF
--- a/Converter/CMakeLists.txt
+++ b/Converter/CMakeLists.txt
@@ -40,6 +40,7 @@ set(${PROJECT_NAME}_HDRS
   igtlioStatusConverter.h
   igtlioTransformConverter.h
   igtlioStringConverter.h
+  igtlioUsSectorDefinitions.h
   )
 
 IF(OpenIGTLink_ENABLE_VIDEOSTREAMING)

--- a/Converter/igtlioUsSectorDefinitions.h
+++ b/Converter/igtlioUsSectorDefinitions.h
@@ -1,0 +1,23 @@
+#ifndef IGTLIOUSSECTORDEFINITIONS_H
+#define IGTLIOUSSECTORDEFINITIONS_H
+
+
+// This defines the meta information tag names for OpenIGTLinkIO ultrasound messages
+#define IGTLIO_KEY_PROBE_TYPE   "ProbeType"
+#define IGTLIO_KEY_ORIGIN       "Origin"
+#define IGTLIO_KEY_ANGLES       "Angles"
+#define IGTLIO_KEY_BOUNDING_BOX "BoundingBox"
+#define IGTLIO_KEY_DEPTHS       "Depths"
+#define IGTLIO_KEY_LINEAR_WIDTH "LinearWidth"
+#define IGTLIO_KEY_SPACING_X    "SpacingX"
+#define IGTLIO_KEY_SPACING_Y    "SpacingY"
+
+enum IGTLIO_PROBE_TYPE
+{
+  UNKNOWN,
+  SECTOR,
+  LINEAR,
+  MECHANICAL
+};
+
+#endif // IGTLIOUSSECTORDEFINITIONS_H


### PR DESCRIPTION
After this is merged, the pull request for PlusLib where this is removed can be performed.