### PR TITLE
BUG: Avoid very fast loop when OpenIGT Client fails to connect to server

### DIFF
--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -354,7 +354,7 @@ void* igtlioConnector::ConnectionAcceptThreadFunction(void* ptr)
       if (connector->Sockets.empty())
         {
           igtl::ClientSocket::Pointer socket = igtl::ClientSocket::New();
-          int r = socket->ConnectToServer(connector->ServerHostname.c_str(), connector->ServerPort);
+          int r = socket->ConnectToServer(connector->ServerHostname.c_str(), connector->ServerPort, false);
           if (r == 0) // if connected to server
           {
             igtlioLockGuard<vtkMutexLock> lock(connector->ClientMutex);
@@ -362,6 +362,12 @@ void* igtlioConnector::ConnectionAcceptThreadFunction(void* ptr)
             Client clientInfo = Client(0, socket, clientThreadID);
             connector->Sockets.push_back(clientInfo);
             connector->RequestInvokeEvent(ClientConnectedEvent);
+          }
+          else
+          {
+            // Delay is required for situations where the ConnectToServer function exits without delay
+            // Without it, the loop will be processed extremely quickly and cause the program to hang
+            igtl::Sleep(100);
           }
         }
       }


### PR DESCRIPTION
Two changes made in consultation with @lassoan:
1. Add a sleep call after failing to connect to server (otherwise it will try every frame)
2. Don't output an error message when connecting from ConnectionAcceptThreadFunction() and type is TYPE_CLIENT
