### PR TITLE
Rearrange device events in ReceiveIGTLMessage and add AboutToReceiveEvent

### DIFF
--- a/Devices/igtlioDevice.h
+++ b/Devices/igtlioDevice.h
@@ -50,6 +50,7 @@ public:
  };
 
  enum {
+   AboutToReceiveEvent   = 118947,
    ReceiveEvent          = 118948,
    ResponseEvent         = 118952,
    ModifiedEvent         = vtkCommand::ModifiedEvent,

--- a/Devices/igtlioImageDevice.cxx
+++ b/Devices/igtlioImageDevice.cxx
@@ -76,15 +76,13 @@ igtlioImageConverter::ContentData igtlioImageDevice::GetContent()
 //---------------------------------------------------------------------------
 int igtlioImageDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (igtlioImageConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo))
-   {
-   this->Modified();
-   this->InvokeEvent(ImageModifiedEvent, this);
-   this->InvokeEvent(ReceiveEvent, NULL);
-   return 1;
-   }
-
- return 0;
+  int success = igtlioImageConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo);
+  if (success)
+    {
+    this->Modified();
+    this->InvokeEvent(ImageModifiedEvent, this);
+    }
+  return success;
 }
 
 

--- a/Devices/igtlioPolyDataDevice.cxx
+++ b/Devices/igtlioPolyDataDevice.cxx
@@ -63,15 +63,12 @@ std::string igtlioPolyDataDevice::GetDeviceType() const
 //---------------------------------------------------------------------------
 int igtlioPolyDataDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (igtlioPolyDataConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo))
- {
-   this->Modified();
-   this->InvokeEvent(ReceiveEvent);
-   this->InvokeEvent(PolyDataModifiedEvent, this);
-   return 1;
- }
-
- return 0;
+  int success = igtlioPolyDataConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo);
+  if (success)
+  {
+    this->Modified();
+  }
+  return success;
 }
 
 //---------------------------------------------------------------------------

--- a/Devices/igtlioStatusDevice.cxx
+++ b/Devices/igtlioStatusDevice.cxx
@@ -49,15 +49,13 @@ std::string igtlioStatusDevice::GetDeviceType() const
 //---------------------------------------------------------------------------
 int igtlioStatusDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (igtlioStatusConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo))
- {
-   this->Modified();
-   this->InvokeEvent(StatusModifiedEvent, this);
-   this->InvokeEvent(ReceiveEvent);
-   return 1;
- }
-
- return 0;
+  int success = igtlioStatusConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo);
+  if (success)
+  {
+    this->Modified();
+    this->InvokeEvent(StatusModifiedEvent, this);
+  }
+  return success;
 }
 
 //---------------------------------------------------------------------------

--- a/Devices/igtlioStringDevice.cxx
+++ b/Devices/igtlioStringDevice.cxx
@@ -49,15 +49,13 @@ unsigned int igtlioStringDevice::GetDeviceContentModifiedEvent() const
 //---------------------------------------------------------------------------
 int igtlioStringDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (igtlioStringConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo))
- {
-   this->Modified();
-   this->InvokeEvent(ReceiveEvent);
-   this->InvokeEvent(StringModifiedEvent, this);
-   return 1;
- }
-
- return 0;
+  int success = igtlioStringConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo);
+  if (success)
+  {
+    this->Modified();
+    this->InvokeEvent(StringModifiedEvent, this);
+  }
+  return success;
 }
 
 //---------------------------------------------------------------------------

--- a/Devices/igtlioTransformDevice.cxx
+++ b/Devices/igtlioTransformDevice.cxx
@@ -75,15 +75,13 @@ igtlioTransformConverter::ContentData igtlioTransformDevice::GetContent()
 //---------------------------------------------------------------------------
 int igtlioTransformDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
- if (igtlioTransformConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo))
- {
-   this->Modified();
-   this->InvokeEvent(TransformModifiedEvent, this);
-   this->InvokeEvent(ReceiveEvent);
-   return 1;
- }
-
- return 0;
+  int success = igtlioTransformConverter::fromIGTL(buffer, &HeaderData, &Content, checkCRC, this->metaInfo);
+  if (success)
+  {
+    this->Modified();
+    this->InvokeEvent(TransformModifiedEvent, this);
+  }
+ return success;
 }
 
 

--- a/Devices/igtlioVideoDevice.cxx
+++ b/Devices/igtlioVideoDevice.cxx
@@ -140,26 +140,24 @@ igtl::VideoMessage::Pointer  igtlioVideoDevice::GetKeyFrameMessage()
 //---------------------------------------------------------------------------
 int igtlioVideoDevice::ReceiveIGTLMessage(igtl::MessageBase::Pointer buffer, bool checkCRC)
 {
+  int success = 0;
   igtl::MessageHeader::Pointer headerMsg = igtl::MessageHeader::New();
   headerMsg->Copy(buffer);
   if(strcmp(headerMsg->GetDeviceName(), this->GetDeviceName().c_str())==0)
     {
     // Copy the current received video message
 
-    int returnValue = 0;
     //To Do, we need to unpack the buffer to know the codec type, which is done in the converter
     // So the user need to set the correct CurrentCodecType before hand.
-    returnValue = igtlioVideoConverter::fromIGTL(buffer, &HeaderData, &Content, this->DecodersMap, checkCRC, this->metaInfo);
-
-    if (returnValue)
-     {
-     this->SetCurrentCodecType(std::string(Content.codecName));
-     this->Modified();
-     this->InvokeEvent(VideoModifiedEvent, this);
-     return 1;
-     }
-  }
- return 0;
+    success = igtlioVideoConverter::fromIGTL(buffer, &HeaderData, &Content, this->DecodersMap, checkCRC, this->metaInfo);
+    if (success)
+      {
+      this->SetCurrentCodecType(std::string(Content.codecName));
+      this->Modified();
+      this->InvokeEvent(VideoModifiedEvent, this);
+      }
+    }
+  return success;
 }
 
 

--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -739,7 +739,9 @@ void igtlioConnector::ImportDataFromCircularBuffer()
         this->AddDevice(device);
       }
 
+      device->InvokeEvent(igtlioDevice::AboutToReceiveEvent);
       device->ReceiveIGTLMessage(messageFromBuffer, this->CheckCRC);
+      device->InvokeEvent(igtlioDevice::ReceiveEvent);
     }
     if (device)
       {

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -133,7 +133,6 @@ public:
     DisconnectedEvent           = 118945,
     ActivatedEvent              = 118946,
     DeactivatedEvent            = 118947,
-//  ReceiveEvent                = 118948,
     NewDeviceEvent              = 118949,
     DeviceContentModifiedEvent  = 118950, // invoked by the devices
     RemovedDeviceEvent          = 118951,


### PR DESCRIPTION
- ReceiveIGTLMessage() now has only one exit point where it returns success or failure.
- Modified and DeviceXYZModifiedEvents are triggered if fromIGTL() is successful.
- ReceiveEvent is invoked whether or not there are issues with fromIGTL() conversion.
- AboutToReceiveEvent is useful for applications such as Slicer that would like to be notified before device content is modified.
