### PR TITLE
Remove warnings about NULL objects

### DIFF
--- a/GUI/qIGTLIOConnectorModel.cxx
+++ b/GUI/qIGTLIOConnectorModel.cxx
@@ -59,7 +59,6 @@ int qIGTLIOConnectorModel::rowCount(const QModelIndex& parent) const
   {
     if (!Logic)
     {
-//        std::cout << "WARNING in: int qIGTLIOConnectorModel::rowCount(const QModelIndex& parent) const: Logic is a NULL object! Returning 0." << std::endl;
         return 0;
     }
     return Logic->GetNumberOfConnectors();

--- a/GUI/qIGTLIOConnectorModel.cxx
+++ b/GUI/qIGTLIOConnectorModel.cxx
@@ -59,7 +59,7 @@ int qIGTLIOConnectorModel::rowCount(const QModelIndex& parent) const
   {
     if (!Logic)
     {
-        std::cout << "WARNING in: int qIGTLIOConnectorModel::rowCount(const QModelIndex& parent) const: Logic is a NULL object! Returning 0." << std::endl;
+//        std::cout << "WARNING in: int qIGTLIOConnectorModel::rowCount(const QModelIndex& parent) const: Logic is a NULL object! Returning 0." << std::endl;
         return 0;
     }
     return Logic->GetNumberOfConnectors();

--- a/GUI/qIGTLIODevicesModel.cxx
+++ b/GUI/qIGTLIODevicesModel.cxx
@@ -53,7 +53,6 @@ int qIGTLIODevicesModel::rowCount(const QModelIndex& parent) const
   qIGTLIODevicesModelNode* node = this->getNodeFromIndex(parent);
   if(!node)
   {
-//      std::cout << "WARNING in: int qIGTLIODevicesModel::rowCount(const QModelIndex& parent) const: node is a NULL object! Returning 0." << std::endl;
       return 0;
   }
 

--- a/GUI/qIGTLIODevicesModel.cxx
+++ b/GUI/qIGTLIODevicesModel.cxx
@@ -53,7 +53,7 @@ int qIGTLIODevicesModel::rowCount(const QModelIndex& parent) const
   qIGTLIODevicesModelNode* node = this->getNodeFromIndex(parent);
   if(!node)
   {
-      std::cout << "WARNING in: int qIGTLIODevicesModel::rowCount(const QModelIndex& parent) const: node is a NULL object! Returning 0." << std::endl;
+//      std::cout << "WARNING in: int qIGTLIODevicesModel::rowCount(const QModelIndex& parent) const: node is a NULL object! Returning 0." << std::endl;
       return 0;
   }
 


### PR DESCRIPTION
Remove warnings about NULL objects in qIGTLIOConnectorModel::rowCount and qIGTLIODevicesModel::rowCount.

These warnings was  probably put there to indicate that the functions were used before the class was initialized, but this doesn't really matter for the rowCount functions. They just return 0.