### PR TITLE
Changes enabling full device name to be transferred over OpenIGTLink

### DIFF
--- a/Converter/igtlioBaseConverter.cxx
+++ b/Converter/igtlioBaseConverter.cxx
@@ -1,9 +1,22 @@
 #include "igtlioBaseConverter.h"
 
+
+// IGTL includes
+#include <igtl_tdata.h>
+
 //---------------------------------------------------------------------------
 int igtlioBaseConverter::IGTLtoHeader(igtl::MessageBase::Pointer source, HeaderData *header, igtl::MessageBase::MetaDataMap& outMetaInfo)
 {
-  header->deviceName = source->GetDeviceName();
+  std::string name;
+  source->GetMetaDataElement(IGTL_DEVICE_NAME_METADATA_KEY, name);
+  if (!name.empty())
+  {
+    header->deviceName = name;
+  }
+  else
+  {
+    header->deviceName = source->GetDeviceName();
+  }
   // get timestamp
   if (IGTLToTimestamp(source, header) == 0)
     return 0;
@@ -23,7 +36,11 @@ int igtlioBaseConverter::IGTLtoHeader(igtl::MessageBase::Pointer source, HeaderD
 //---------------------------------------------------------------------------
 int igtlioBaseConverter::HeadertoIGTL(const HeaderData &header, igtl::MessageBase::Pointer *dest, igtl::MessageBase::MetaDataMap metaInfo)
 {
-  (*dest)->SetDeviceName(header.deviceName.c_str());
+  (*dest)->SetDeviceName(header.deviceName.substr(0, IGTL_TDATA_LEN_NAME).c_str());
+  if (header.deviceName.length() > IGTL_TDATA_LEN_NAME)
+  {
+    (*dest)->SetMetaDataElement(IGTL_DEVICE_NAME_METADATA_KEY, IANA_TYPE_US_ASCII, header.deviceName);
+  }
   for (igtl::MessageBase::MetaDataMap::const_iterator it = metaInfo.begin(); it != metaInfo.end(); ++it)
     {
     std::string key = it->first;

--- a/Converter/igtlioBaseConverter.h
+++ b/Converter/igtlioBaseConverter.h
@@ -16,8 +16,8 @@
 template <class T, class U>
 igtl::SmartPointer<T> dynamic_pointer_cast(const igtl::SmartPointer<U>& sp) //noexcept
 {
- T* ptr = dynamic_cast<T*>(sp.GetPointer());
- return igtl::SmartPointer<T>(ptr);
+  T* ptr = dynamic_cast<T*>(sp.GetPointer());
+  return igtl::SmartPointer<T>(ptr);
 }
 //---------------------------------------------------------------------------
 
@@ -33,14 +33,14 @@ public:
    */
   struct HeaderData
   {
-  std::string deviceName;
-  double timestamp;
+    std::string deviceName;
+    double timestamp;
   };
 
   static int IGTLtoHeader(igtl::MessageBase::Pointer source, HeaderData* header, igtl::MessageBase::MetaDataMap& outMetaInfo);
   static int HeadertoIGTL(const HeaderData& header, igtl::MessageBase::Pointer* dest, igtl::MessageBase::MetaDataMap metaInfo = igtl::MessageBase::MetaDataMap());
 
-  static int IGTLToTimestamp(igtl::MessageBase::Pointer msg, HeaderData *dest);
+  static int IGTLToTimestamp(igtl::MessageBase::Pointer msg, HeaderData* dest);
 };
 
 #endif // IGTLIOBASECONVERTER_H

--- a/Converter/igtlioTransformConverter.cxx
+++ b/Converter/igtlioTransformConverter.cxx
@@ -94,7 +94,6 @@ int igtlioTransformConverter::fromIGTL(igtl::MessageBase::Pointer source,
     //transformToParent->Print(cerr);
 
     dest->transform = transform;
-    dest->deviceName = transMsg->GetDeviceName();
 
     return 1;
 
@@ -158,7 +157,6 @@ int igtlioTransformConverter::toIGTL(const HeaderData& header, const ContentData
   igtlmatrix[3][3]  = matrix->Element[3][3];
 
   msg->SetMatrix(igtlmatrix);
-  msg->SetDeviceName(source.deviceName.c_str());
   msg->Pack();
 
   return 1;

--- a/Converter/igtlioTransformConverter.h
+++ b/Converter/igtlioTransformConverter.h
@@ -36,7 +36,6 @@ public:
   struct ContentData
   {
   vtkSmartPointer<vtkMatrix4x4> transform;
-  std::string deviceName;
   std::string streamIdTo;
   std::string streamIdFrom;
   };

--- a/Logic/igtlioSession.cxx
+++ b/Logic/igtlioSession.cxx
@@ -172,8 +172,8 @@ igtlioTransformDevicePointer igtlioSession::SendTransform(std::string device_id,
   device = igtlioTransformDevice::SafeDownCast(Connector->AddDeviceIfNotPresent(key));
 
   igtlioTransformConverter::ContentData contentdata = device->GetContent();
-  contentdata.deviceName = device_id;
   contentdata.transform = transform;
+  device->SetDeviceName(device_id);
   device->SetContent(contentdata);
 
   Connector->SendMessage(igtlioDeviceKeyType::CreateDeviceKey(device));


### PR DESCRIPTION
Relies on 
https://github.com/openigtlink/OpenIGTLink/pull/207

This change grabs the device name from metadata if present, otherwise falls back to 20 char limit field