### PR TITLE
Add meta information tag names for scanner timestamp and z spacing

### DIFF
--- a/Converter/igtlioUsSectorDefinitions.h
+++ b/Converter/igtlioUsSectorDefinitions.h
@@ -11,6 +11,8 @@
 #define IGTLIO_KEY_LINEAR_WIDTH "LinearWidth"
 #define IGTLIO_KEY_SPACING_X    "SpacingX"
 #define IGTLIO_KEY_SPACING_Y    "SpacingY"
+#define IGTLIO_KEY_SPACING_Z    "SpacingZ"
+#define IGTLIO_KEY_TIMESTAMP    "Timestamp"
 
 enum IGTLIO_PROBE_TYPE
 {

--- a/Converter/igtlioUsSectorDefinitions.h
+++ b/Converter/igtlioUsSectorDefinitions.h
@@ -12,7 +12,7 @@
 #define IGTLIO_KEY_SPACING_X    "SpacingX"
 #define IGTLIO_KEY_SPACING_Y    "SpacingY"
 #define IGTLIO_KEY_SPACING_Z    "SpacingZ"
-#define IGTLIO_KEY_TIMESTAMP    "Timestamp"
+#define IGTLIO_KEY_TIMESTAMP    "ScannerTimestamp"
 
 enum IGTLIO_PROBE_TYPE
 {


### PR DESCRIPTION
Adding two more meta information tag names for sending scanner timestamps and z spacing with ultrasound images