### PR TITLE
Handle RTS_TDATA to address IGSIO/OpenIGTLinkIO#94 .

### DIFF
--- a/Converter/igtlioTrackingDataConverter.cxx
+++ b/Converter/igtlioTrackingDataConverter.cxx
@@ -20,6 +20,13 @@ int igtlioTrackingDataConverter::fromIGTL(igtl::MessageBase::Pointer source,
     bool checkCRC,
     igtl::MessageBase::MetaDataMap& outMetaInfo)
 {
+
+  // Process an RTS_TDATA sub-type message
+  if (strncmp(source->GetDeviceType(), "RTS_", 4) == 0)
+  {
+    return fromIGTLResponse(source, header, dest, checkCRC, outMetaInfo);
+  }
+
   // Create a message buffer to receive image data
   igtl::TrackingDataMessage::Pointer transMsg;
   transMsg = igtl::TrackingDataMessage::New();
@@ -114,6 +121,42 @@ int igtlioTrackingDataConverter::fromIGTL(igtl::MessageBase::Pointer source,
   return 1;
 
 }
+
+
+//---------------------------------------------------------------------------
+int igtlioTrackingDataConverter::fromIGTLResponse(igtl::MessageBase::Pointer source, HeaderData *header, ContentData *dest, bool checkCRC, igtl::MessageBase::MetaDataMap& outMetaInfo)
+{
+  // Handler for RTS_* message
+  // TODO: This could be implemented in the parent class.
+
+  igtl::RTSTrackingDataMessage::Pointer rtsMsg;
+  rtsMsg = igtl::RTSTrackingDataMessage::New();
+  rtsMsg->Copy(source);
+
+  // Deserialize the transform data
+  // If CheckCRC==0, CRC check is skipped.
+  int c = rtsMsg->Unpack(checkCRC);
+
+  if (!(c & igtl::MessageHeader::UNPACK_BODY)) // if CRC check fails
+  {
+    // TODO: error handling
+    return 0;
+  }
+
+  // get header
+  if (!IGTLtoHeader(dynamic_pointer_cast<igtl::MessageBase>(rtsMsg), header, outMetaInfo))
+  {
+    return 0;
+  }
+
+  //
+  // TODO: RTS status should be passed to dest (ContentData needs to be updated to store the RTS status)
+  //
+
+  return 1;
+
+}
+
 
 //---------------------------------------------------------------------------
 int igtlioTrackingDataConverter::IGTLHeaderToTDATAInfo(igtl::MessageBase::Pointer source, ContentData* dest)

--- a/Converter/igtlioTrackingDataConverter.cxx
+++ b/Converter/igtlioTrackingDataConverter.cxx
@@ -22,7 +22,7 @@ int igtlioTrackingDataConverter::fromIGTL(igtl::MessageBase::Pointer source,
 {
 
   // Process an RTS_TDATA sub-type message
-  if (strncmp(source->GetDeviceType(), "RTS_", 4) == 0)
+  if (source->GetMessageType().compare(0, 4, "RTS_") == 0)
   {
     return fromIGTLResponse(source, header, dest, checkCRC, outMetaInfo);
   }

--- a/Converter/igtlioTrackingDataConverter.h
+++ b/Converter/igtlioTrackingDataConverter.h
@@ -52,6 +52,8 @@ public:
   static int fromIGTL(igtl::MessageBase::Pointer source, HeaderData* header, ContentData* content, bool checkCRC, igtl::MessageBase::MetaDataMap& outMetaInfo);
   static int toIGTL(const HeaderData& header, const ContentData& source, igtl::TrackingDataMessage::Pointer* dest, igtl::MessageBase::MetaDataMap metaInfo = igtl::MessageBase::MetaDataMap());
 
+  static int fromIGTLResponse(igtl::MessageBase::Pointer source, HeaderData *header, ContentData *dest, bool checkCRC, igtl::MessageBase::MetaDataMap& outMetaInfo);
+
   static int IGTLToVTKTDATA(const igtl::Matrix4x4& igtlTDATA, vtkSmartPointer<vtkMatrix4x4> vtkTDATA);
   static int VTKToIGTLTDATA(const vtkMatrix4x4& vtkTDATA, igtl::Matrix4x4& igtlTDATA);
 


### PR DESCRIPTION
This is a quick fix for IGSIO/OpenIGTLinkIO#94. The library might have similar issues with any message types with RTS_*, STT_*, and STP_* subtypes, but this pull request won't fix them. Ultimately, handlers for those subtypes should be implemented in the base converter class. 