### PR TITLE
Compile with Qt 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,10 @@ if(NOT IGTLIO_QT_VERSION)
   set(IGTLIO_QT_VERSION "5" CACHE STRING "Expected Qt version")
   mark_as_advanced( IGTLIO_QT_VERSION )
 endif()
-set_property(CACHE IGTLIO_QT_VERSION PROPERTY STRINGS 4 5)
+set_property(CACHE IGTLIO_QT_VERSION PROPERTY STRINGS 5 6)
 
-if(NOT (IGTLIO_QT_VERSION VERSION_EQUAL "4" OR IGTLIO_QT_VERSION VERSION_EQUAL "5"))
-    message(FATAL_ERROR "Expected value for IGTLIO_QT_VERSION is either '4' or '5'")
+if(NOT (IGTLIO_QT_VERSION VERSION_EQUAL "5" OR IGTLIO_QT_VERSION VERSION_EQUAL "6"))
+    message(FATAL_ERROR "Expected value for IGTLIO_QT_VERSION is either '5' or '6'")
 endif()
 
 set (OpenIGTLinkIO_TARGETS igtlioLogic igtlioDevices igtlioConverter igtlioTools )
@@ -104,14 +104,6 @@ set(OpenIGTLinkIO_Qt_CONFIG_CODE "")
 if (${IGTLIO_USE_GUI})
   add_subdirectory(GUI)
   list (APPEND OpenIGTLinkIO_TARGETS igtlioGUI)
-  # CMake is not able to generate the makefile on Linux if the 
-  # target Qt5::X11Extras is not defined in this directory
-  # when IGTLIO_USE_GUI is ON. The fix is necessary because
-  # X11Extras is a private dependency of vtk at least 
-  # until vtk-8.1 and maybe later.
-  if(UNIX AND NOT APPLE)
-    find_package(Qt5 COMPONENTS X11Extras REQUIRED)
-  endif()
 endif()
 
 option(IGTLIO_USE_EXAMPLES "Build IGTLIO examples" ON)

--- a/Devices/igtlioVideoDevice.cxx
+++ b/Devices/igtlioVideoDevice.cxx
@@ -181,7 +181,7 @@ igtl::MessageBase::Pointer igtlioVideoDevice::GetIGTLMessage()
   if(this->CurrentCodecType.compare(IGTL_VIDEO_CODEC_NAME_I420) == 0)
   {
     VideoStreamEncoderI420->SetPicWidthAndHeight(imageSizePixels[0], imageSizePixels[1]);
-    VideoStreamEncoderI420->SetRCTaregetBitRate((int)(imageSizePixels[0] * imageSizePixels[1] * 8 * frameRate * bitRatePercent));
+    VideoStreamEncoderI420->SetRCTargetBitRate((int)(imageSizePixels[0] * imageSizePixels[1] * 8 * frameRate * bitRatePercent));
     Content.videoMessage->SetCodecType(IGTL_VIDEO_CODEC_NAME_I420);
     iReturn = igtlioVideoConverter::toIGTL(HeaderData, Content, VideoStreamEncoderI420, this->metaInfo);
   }
@@ -190,7 +190,7 @@ igtl::MessageBase::Pointer igtlioVideoDevice::GetIGTLMessage()
     {
     VideoStreamEncoderH264->SetPicWidthAndHeight(imageSizePixels[0], imageSizePixels[1]);
     //newEncoder->SetKeyFrameDistance(25);
-    VideoStreamEncoderH264->SetRCTaregetBitRate((int)(imageSizePixels[0] * imageSizePixels[1] * 8 * frameRate * bitRatePercent));
+    VideoStreamEncoderH264->SetRCTargetBitRate((int)(imageSizePixels[0] * imageSizePixels[1] * 8 * frameRate * bitRatePercent));
     Content.videoMessage->SetCodecType(IGTL_VIDEO_CODEC_NAME_H264);
     iReturn = igtlioVideoConverter::toIGTL(HeaderData, Content, VideoStreamEncoderH264, this->metaInfo);
     }
@@ -200,7 +200,7 @@ igtl::MessageBase::Pointer igtlioVideoDevice::GetIGTLMessage()
     {
     VideoStreamEncoderVPX->SetPicWidthAndHeight(imageSizePixels[0], imageSizePixels[1]);
     //newEncoder->SetKeyFrameDistance(25);
-    VideoStreamEncoderVPX->SetRCTaregetBitRate((int)(imageSizePixels[0] * imageSizePixels[1] * 8 * frameRate * bitRatePercent));
+    VideoStreamEncoderVPX->SetRCTargetBitRate((int)(imageSizePixels[0] * imageSizePixels[1] * 8 * frameRate * bitRatePercent));
     Content.videoMessage->SetCodecType(IGTL_VIDEO_CODEC_NAME_VP9);
     iReturn = igtlioVideoConverter::toIGTL(HeaderData, Content, VideoStreamEncoderVPX, this->metaInfo);
     }

--- a/Examples/qIgtlClient/CMakeLists.txt
+++ b/Examples/qIgtlClient/CMakeLists.txt
@@ -21,13 +21,12 @@ set(${PROJECT_NAME}_TARGET_LIBRARIES
   igtlioGUI
   )
 
-if(IGTLIO_QT_VERSION VERSION_GREATER "4")
+if(IGTLIO_QT_VERSION VERSION_EQUAL "5")
   find_package(Qt5 COMPONENTS Widgets REQUIRED)
   list(APPEND ${PROJECT_NAME}_TARGET_LIBRARIES Qt5::Widgets)
 else()
-  find_package(Qt4)
-  include(${QT_USE_FILE})
-  list(APPEND ${PROJECT_NAME}_TARGET_LIBRARIES Qt4::QtGui)
+  find_package(Qt6 COMPONENTS Widgets REQUIRED)
+  list(APPEND ${PROJECT_NAME}_TARGET_LIBRARIES Qt6::Widgets)
 endif()
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS})

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -25,7 +25,7 @@ set(OpenIGTLinkIO_Qt_Modules
   Sql
   )
 
-if(IGTLIO_QT_VERSION VERSION_GREATER "4")
+if(IGTLIO_QT_VERSION VERSION_EQUAL "5")
   find_package(Qt5 COMPONENTS ${OpenIGTLinkIO_Qt_Modules} REQUIRED)
   if(Qt5_FOUND AND NOT Qt5_DIR)
     # Sometimes Qt5_DIR is not populated
@@ -62,16 +62,41 @@ if(IGTLIO_QT_VERSION VERSION_GREATER "4")
     OpenIGTLinkIO_Qt_CONFIG_CODE ${OpenIGTLinkIO_Qt_CONFIG_CODE}
    )
 else()
-  find_package(Qt4 REQUIRED)
-  include(${QT_USE_FILE})
+  find_package(Qt6 COMPONENTS ${OpenIGTLinkIO_Qt_Modules} REQUIRED)
+  if(Qt6_FOUND AND NOT Qt6_DIR)
+    # Sometimes Qt5_DIR is not populated
+    get_filename_component(Qt6_DIR ${Qt6Core_DIR} DIRECTORY)
+    set(Qt6_DIR ${Qt6_DIR}/Qt6)
+  endif()
 
-  # Prepare Config file code for Qt
+  # Prepare config file code for Qt
   set(OpenIGTLinkIO_Qt_CONFIG_CODE [=[
-    # using Qt4
-    set(QT_QMAKE_EXECUTABLE "@QT_QMAKE_EXECUTABLE@")
-    find_package(Qt4 COMPONENTS @OpenIGTLinkIO_Qt_Modules@ REQUIRED)
+    if(Qt6_FOUND)
+      # using Qt5
+      set(IGTL_Qt6_FOUND True)
+    elseif(NOT Qt6_DIR)
+      # only set, if not in cache
+      set(Qt6_DIR "@Qt6_DIR@")
+    endif()
+    find_package(Qt6 COMPONENTS @OpenIGTLinkIO_Qt_Modules@ REQUIRED)
+    if(IGTL_Qt6_FOUND)
+      @_VERSION_CONFIG_CODE@
+    endif()
     ]=])
-  string(REPLACE "@QT_QMAKE_EXECUTABLE@" "${QT_QMAKE_EXECUTABLE}" OpenIGTLinkIO_Qt_CONFIG_CODE ${OpenIGTLinkIO_Qt_CONFIG_CODE})
+
+  set(_VERSION_CONFIG_CODE)
+  foreach(qt_module IN LISTS OpenIGTLinkIO_Qt_Modules)
+    set(_VERSION_CONFIG_CODE "${_VERSION_CONFIG_CODE}\nif(TARGET Qt6::${qt_module} AND NOT \"${Qt6${qt_module}_VERSION}\" VERSION_EQUAL \${Qt6${qt_module}_VERSION})")
+    set(_VERSION_CONFIG_CODE "${_VERSION_CONFIG_CODE}\nmessage(SEND_ERROR \"Using different Qt Versions for Qt6::${qt_module} in OpenIGTLinkIO (${Qt6${qt_module}_VERSION}) and superceeding project (\${Qt6${qt_module}_VERSION}).\")")
+    set(_VERSION_CONFIG_CODE "${_VERSION_CONFIG_CODE}\nendif()")
+  endforeach()
+
+  string(REPLACE "@_VERSION_CONFIG_CODE@" "${_VERSION_CONFIG_CODE}" 
+    OpenIGTLinkIO_Qt_CONFIG_CODE ${OpenIGTLinkIO_Qt_CONFIG_CODE}
+   )
+  string(REPLACE "@Qt6_DIR@" "${Qt6_DIR}"
+    OpenIGTLinkIO_Qt_CONFIG_CODE ${OpenIGTLinkIO_Qt_CONFIG_CODE}
+   )
 endif()
 
 string(REPLACE ";" " " OpenIGTLinkIO_Qt_Modules_Glued "${OpenIGTLinkIO_Qt_Modules}")
@@ -140,9 +165,7 @@ set(${PROJECT_NAME}_INCLUDE_DIRECTORIES PUBLIC
   $<INSTALL_INTERFACE:${OpenIGTLinkIO_INCLUDE_INSTALL}/DeviceWidgets>
   )
 
-if(IGTLIO_QT_VERSION VERSION_GREATER "4")
-  qt5_wrap_ui(${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_UI_SRCS})
-  qt5_wrap_cpp( ${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_MOC_SRCS})
+if(IGTLIO_QT_VERSION VERSION_EQUAL "5")
   set( igtlio_qt_libraries 
     Qt5::Widgets 
     Qt5::Concurrent 
@@ -150,12 +173,18 @@ if(IGTLIO_QT_VERSION VERSION_GREATER "4")
     Qt5::Xml 
     Qt5::OpenGL
    )
+  qt5_wrap_ui(${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_UI_SRCS})
+  qt5_wrap_cpp( ${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_MOC_SRCS})
 else()
-  QT4_WRAP_CPP( ${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_MOC_SRCS})
-  QT4_WRAP_UI( ${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_UI_SRCS})
   set( igtlio_qt_libraries 
-    Qt4::QtGui 
+    Qt6::Widgets 
+    Qt6::Concurrent 
+    Qt6::Sql 
+    Qt6::Xml 
+    Qt6::OpenGL
    )
+  qt6_wrap_ui(${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_UI_SRCS})
+  qt6_wrap_cpp( ${PROJECT_NAME}_SRCS ${${PROJECT_NAME}_MOC_SRCS})
 endif()
 
 set(${PROJECT_NAME}_TARGET_LIBRARIES

--- a/GUI/qIGTLIOConnectorListWidget.cxx
+++ b/GUI/qIGTLIOConnectorListWidget.cxx
@@ -15,7 +15,7 @@ qIGTLIOConnectorListWidget::qIGTLIOConnectorListWidget()
   ConnectorModel = new qIGTLIOConnectorModel(this);
 
   QVBoxLayout* topLayout = new QVBoxLayout(this);
-  topLayout->setMargin(0);
+  topLayout->setContentsMargins(0, 0, 0, 0);
 
   ConnectorListView = new QTreeView;
   ConnectorListView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -54,7 +54,7 @@ void qIGTLIOConnectorListWidget::addButtonFrame(QVBoxLayout* topLayout)
   buttonFrame->setFrameShadow(QFrame::Plain);
   topLayout->addWidget(buttonFrame);
   QHBoxLayout* buttonLayout = new QHBoxLayout(buttonFrame);
-  buttonLayout->setMargin(0);
+  buttonLayout->setContentsMargins(0, 0, 0, 0);
 
   QAction* addAction = new QAction("+", this);
   connect(addAction, SIGNAL(triggered()), this, SLOT(onAddConnectorButtonClicked()));

--- a/GUI/qIGTLIODeviceAddWidget.cxx
+++ b/GUI/qIGTLIODeviceAddWidget.cxx
@@ -17,14 +17,14 @@
 qIGTLIODeviceAddWidget::qIGTLIODeviceAddWidget()
 {
   QVBoxLayout* topLayout = new QVBoxLayout(this);
-  topLayout->setMargin(0);
+  topLayout->setContentsMargins(0, 0, 0, 0);
 
   QFrame* buttonFrame = new QFrame;
   buttonFrame->setFrameShape(QFrame::NoFrame);
   buttonFrame->setFrameShadow(QFrame::Plain);
   topLayout->addWidget(buttonFrame);
   QHBoxLayout* buttonLayout = new QHBoxLayout(buttonFrame);
-  buttonLayout->setMargin(0);
+  buttonLayout->setContentsMargins(0, 0, 0, 0);
 
   mAddDeviceAction = new QAction("Add Device", this);
   connect(mAddDeviceAction, SIGNAL(triggered()), this, SLOT(onAddDevice()));

--- a/GUI/qIGTLIODeviceButtonsWidget.cxx
+++ b/GUI/qIGTLIODeviceButtonsWidget.cxx
@@ -11,17 +11,20 @@
 #include <QItemSelectionModel>
 #include "vtkIGTLIONode.h"
 
+#pragma push_macro("SendMessage")
+#undef SendMessage
+
 qIGTLIODeviceButtonsWidget::qIGTLIODeviceButtonsWidget()
 {
   QVBoxLayout* topLayout = new QVBoxLayout(this);
-  topLayout->setMargin(0);
+  topLayout->setContentsMargins(0, 0, 0, 0);
 
   QFrame* buttonFrame = new QFrame;
   buttonFrame->setFrameShape(QFrame::NoFrame);
   buttonFrame->setFrameShadow(QFrame::Plain);
   topLayout->addWidget(buttonFrame);
   QHBoxLayout* buttonLayout = new QHBoxLayout(buttonFrame);
-  buttonLayout->setMargin(0);
+  buttonLayout->setContentsMargins(0, 0, 0, 0);
 
   QStringList actionNames = QStringList() << "SEND";
 
@@ -96,3 +99,5 @@ void qIGTLIODeviceButtonsWidget::onActionClicked()
   node->connector->SendMessage(igtlioDeviceKeyType::CreateDeviceKey(node->device), prefix);
 
 }
+
+#pragma pop_macro("SendMessage")

--- a/GUI/qIGTLIODevicePropertiesWidget.cxx
+++ b/GUI/qIGTLIODevicePropertiesWidget.cxx
@@ -15,7 +15,7 @@ public:
     groupBox = new QGroupBox(header);
     parentLayout->addWidget(groupBox);
     layout = new QVBoxLayout(groupBox);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
   }
 
   void replaceWidget(QWidget* newWidget)
@@ -46,7 +46,7 @@ qIGTLIODevicePropertiesWidget::qIGTLIODevicePropertiesWidget(QWidget* parent) : 
   DeviceWidgetFactory = vtkIGTLIODeviceWidgetFactoryPointer::New();
 
   QVBoxLayout* layout = new QVBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
 
   WidgetInGroupBox = new WidgetInGroupBoxClass(layout, "Device");
 }

--- a/GUI/qIGTLIODevicesWidget.cxx
+++ b/GUI/qIGTLIODevicesWidget.cxx
@@ -19,7 +19,7 @@ qIGTLIODevicesWidget::qIGTLIODevicesWidget()
   DevicesModel = new qIGTLIODevicesModel(this);
 
   QVBoxLayout* topLayout = new QVBoxLayout(this);
-  topLayout->setMargin(0);
+  topLayout->setContentsMargins(0, 0, 0, 0);
 
   DevicesListView = new QTreeView;
   DevicesListView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/Logic/igtlioConnector.cxx
+++ b/Logic/igtlioConnector.cxx
@@ -50,6 +50,9 @@ Version:   $Revision: 1.4 $
 
 #include "igtlioConnector.h"
 
+#pragma push_macro("SendMessage")
+#undef SendMessage
+
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(igtlioConnector);
 //----------------------------------------------------------------------------
@@ -1349,3 +1352,5 @@ bool operator<(const igtlioConnector::SectionBufferKey& lhs, const igtlioConnect
   }
   return false;
 };
+
+#pragma pop_macro("SendMessage")

--- a/Logic/igtlioConnector.h
+++ b/Logic/igtlioConnector.h
@@ -38,6 +38,12 @@
 #include <set>
 #include <queue>
 
+
+// The macro SendMessage in winuser.h clashes with the method name in igtlioConnector.
+// A simple workaround is to undefine this macro to avoid name conflict (https://stackoverflow.com/a/69041270)
+#pragma push_macro("SendMessage")
+#undef SendMessage
+
 typedef vtkSmartPointer<class vtkMultiThreader> vtkMultiThreaderPointer;
 typedef std::vector< vtkSmartPointer<igtlioDevice> >   igtlioMessageDeviceListType;
 typedef std::deque<igtlioCommandPointer> igtlioCommandDequeType;
@@ -414,4 +420,5 @@ protected:
 
 bool operator<(const igtlioConnector::SectionBufferKey& lhs, const igtlioConnector::SectionBufferKey& rhs);
 
+#pragma pop_macro("SendMessage")
 #endif

--- a/Logic/igtlioSession.cxx
+++ b/Logic/igtlioSession.cxx
@@ -14,6 +14,9 @@
   #include "igtlioVideoDevice.h"
 #endif
 
+#pragma push_macro("SendMessage")
+#undef SendMessage
+
 //---------------------------------------------------------------------------
 vtkStandardNewMacro(igtlioSession);
 
@@ -214,3 +217,5 @@ igtlioStatusDevicePointer igtlioSession::SendStatus(std::string device_id, int c
 
   return device;
 }
+
+#pragma pop_macro("SendMessage")


### PR DESCRIPTION
* The macro SendMessage in winuser.h clashes with the method name in igtlioConnector. I would guess Qt6 now includes this somewhere where Qt5 wasn't. The cleaner way to resolve this would be to rename the SendMessage method to something unique, but this would require also changing every other application using OIGTLIO.

* Remove Qt 4 support